### PR TITLE
Rename repository and use test-app docker image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>spring-cloud-kubernetes-deployer</artifactId>
+	<artifactId>spring-cloud-deployer-kubernetes</artifactId>
 	<version>1.0.0.BUILD-SNAPSHOT</version>
 	<groupId>org.springframework.cloud</groupId>
 	<packaging>jar</packaging>
 
-	<name>spring-cloud-kubernetes-deployer</name>
-	<description>Spring Cloud - Kubernetes Deployer</description>
+	<name>spring-cloud-deployer-kubernetes</name>
+	<description>Spring Cloud - Deployer for Kubernetes</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -19,8 +19,8 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<kubernetes-client.version>1.3.82</kubernetes-client.version>
-		<kubernetes-assertions.version>2.2.101</kubernetes-assertions.version>
+		<kubernetes-client.version>1.3.83</kubernetes-client.version>
+		<kubernetes-assertions.version>2.2.110</kubernetes-assertions.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -111,18 +111,10 @@ public class DefaultContainerFactory implements ContainerFactory {
 		Map<String, String> args = request.getDefinition().getProperties();
 		List<String> cmdArgs = new LinkedList<String>();
 		for (Map.Entry<String, String> entry : args.entrySet()) {
-			cmdArgs.add(String.format("--%s=%s", bashEscape(entry.getKey()),
-					bashEscape(entry.getValue())));
+			cmdArgs.add(String.format("--%s=%s", entry.getKey(), entry.getValue()));
 		}
 		logger.debug("Using command args: " + cmdArgs);
 		return cmdArgs;
 	}
 
-	/**
-	 * Escape arguments
-	 */
-	protected String bashEscape(String original) {
-		// Adapted from http://ruby-doc.org/stdlib-1.9.3/libdoc/shellwords/rdoc/Shellwords.html#method-c-shellescape
-		return original.replaceAll("([^A-Za-z0-9_\\-.,:\\/@\\n])", "\\\\$1").replaceAll("\n", "'\\\\n'");
-	}
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -58,6 +58,6 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 	@Override
 	protected Resource integrationTestProcessor() {
 		//TODO: create a project that builds docker image for testing
-		return new DockerResource("trisberg/deployer-test-app:latest");
+		return new DockerResource("springcloud/spring-cloud-deployer-spi-test-app:latest");
 	}
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -57,7 +57,6 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 
 	@Override
 	protected Resource integrationTestProcessor() {
-		//TODO: create a project that builds docker image for testing
 		return new DockerResource("springcloud/spring-cloud-deployer-spi-test-app:latest");
 	}
 }


### PR DESCRIPTION
- Rename repository to spring-cloud-deployer-kubernetes

- Use test-app docker image for IT tests

- Remove escaping of parameters, not needed

Fixes #10
Fixes #7