### PR TITLE
Improve LoadBalancer handling on undploy

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -99,7 +99,7 @@ public class KubernetesAppDeployer implements AppDeployer {
 			externalPort = Integer.valueOf(parameters.get(SERVER_PORT_KEY));
 		}
 		logger.debug("Creating service: {} on {}", appId, externalPort);
-		createService(appId, idMap, externalPort);
+		createService(appId, request, idMap, externalPort);
 
 		logger.debug("Creating repl controller: {} on {}", appId, externalPort);
 		createReplicationController(appId, request, idMap, externalPort);
@@ -208,9 +208,19 @@ public class KubernetesAppDeployer implements AppDeployer {
 		return podSpec.build();
 	}
 
-	private void createService(String appId, Map<String, String> idMap, int externalPort) {
+	private void createService(String appId, AppDeploymentRequest request, Map<String, String> idMap, int externalPort) {
 		ServiceSpecBuilder spec = new ServiceSpecBuilder();
-		if (properties.isCreateLoadBalancer()) {
+		boolean isCreateLoadBalancer = false;
+		String createLoadBalancer = request.getEnvironmentProperties().get("spring.cloud.deployer.kubernetes.createLoadBalancer");
+		if (createLoadBalancer == null) {
+			isCreateLoadBalancer = properties.isCreateLoadBalancer();
+		}
+		else {
+			if ("true".equals(createLoadBalancer.toLowerCase())) {
+				isCreateLoadBalancer = true;
+			}
+		}
+		if (isCreateLoadBalancer) {
 			spec.withType("LoadBalancer");
 		}
 		spec.withSelector(idMap)

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
@@ -87,6 +87,11 @@ public class KubernetesAppDeployerProperties {
 	private boolean createLoadBalancer = false;
 
 	/**
+	 * Time to wait for load balancer to be available before attempting delete of service (in minutes).
+	 */
+	private int minutesToWaitForLoadBalancer = 5;
+
+	/**
 	 * Maximum allowed restarts for app that fails due to an error or excessive resource use.
 	 */
 	private int maxTerminatedErrorRestarts = 2;
@@ -169,6 +174,22 @@ public class KubernetesAppDeployerProperties {
 		this.environmentVariables = environmentVariables;
 	}
 
+	public boolean isCreateLoadBalancer() {
+		return createLoadBalancer;
+	}
+
+	public void setCreateLoadBalancer(boolean createLoadBalancer) {
+		this.createLoadBalancer = createLoadBalancer;
+	}
+
+	public int getMinutesToWaitForLoadBalancer() {
+		return minutesToWaitForLoadBalancer;
+	}
+
+	public void setMinutesToWaitForLoadBalancer(int minutesToWaitForLoadBalancer) {
+		this.minutesToWaitForLoadBalancer = minutesToWaitForLoadBalancer;
+	}
+
 	public int getMaxTerminatedErrorRestarts() {
 		return maxTerminatedErrorRestarts;
 	}
@@ -183,13 +204,5 @@ public class KubernetesAppDeployerProperties {
 
 	public void setMaxCrashLoopBackOffRestarts(int maxCrashLoopBackOffRestarts) {
 		this.maxCrashLoopBackOffRestarts = maxCrashLoopBackOffRestarts;
-	}
-
-	public boolean isCreateLoadBalancer() {
-		return createLoadBalancer;
-	}
-
-	public void setCreateLoadBalancer(boolean createLoadBalancer) {
-		this.createLoadBalancer = createLoadBalancer;
 	}
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -16,14 +16,31 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.cloud.deployer.spi.app.DeploymentState.deployed;
+import static org.springframework.cloud.deployer.spi.app.DeploymentState.failed;
+import static org.springframework.cloud.deployer.spi.app.DeploymentState.unknown;
+import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
 import org.junit.ClassRule;
+import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.app.AppStatus;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.test.AbstractAppDeployerIntegrationTests;
 import org.springframework.core.io.Resource;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
 
 /**
  * Integration tests for {@link KubernetesAppDeployer}.
@@ -39,9 +56,64 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 	@Autowired
 	private AppDeployer appDeployer;
 
+	@Autowired
+	KubernetesClient kubernetesClient;
+
+	@Autowired
+	ContainerFactory containerFactory;
+
 	@Override
 	protected AppDeployer appDeployer() {
 		return appDeployer;
+	}
+
+	@Test
+	public void testFailedDeploymentWithLoadBalancer() {
+		KubernetesAppDeployerProperties lbProperties = new KubernetesAppDeployerProperties();
+		lbProperties.setCreateLoadBalancer(true);
+		KubernetesAppDeployer lbAppDeployer = new KubernetesAppDeployer(lbProperties, kubernetesClient, containerFactory);
+
+		AppDefinition definition = new AppDefinition(randomName(), null);
+		Resource resource = integrationTestProcessor();
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.memory", "128Mi");
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, props);
+
+		log.info("Deploying {}...", request.getDefinition().getName());
+		String deploymentId = lbAppDeployer.deploy(request);
+		Timeout timeout = deploymentTimeout();
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.<AppStatus>hasProperty("state", is(failed))), timeout.maxAttempts, timeout.pause));
+
+		log.info("Undeploying {}...", deploymentId);
+		timeout = undeploymentTimeout();
+		lbAppDeployer.undeploy(deploymentId);
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.<AppStatus>hasProperty("state", is(unknown))), timeout.maxAttempts, timeout.pause));
+	}
+
+	@Test
+	public void testGoodDeploymentWithLoadBalancer() {
+		KubernetesAppDeployerProperties lbProperties = new KubernetesAppDeployerProperties();
+		lbProperties.setCreateLoadBalancer(true);
+		lbProperties.setMinutesToWaitForLoadBalancer(1);
+		KubernetesAppDeployer lbAppDeployer = new KubernetesAppDeployer(lbProperties, kubernetesClient, containerFactory);
+
+		AppDefinition definition = new AppDefinition(randomName(), null);
+		Resource resource = integrationTestProcessor();
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource);
+
+		log.info("Deploying {}...", request.getDefinition().getName());
+		String deploymentId = lbAppDeployer.deploy(request);
+		Timeout timeout = deploymentTimeout();
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.<AppStatus>hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
+
+		log.info("Undeploying {}...", deploymentId);
+		timeout = undeploymentTimeout();
+		lbAppDeployer.undeploy(deploymentId);
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.<AppStatus>hasProperty("state", is(unknown))), timeout.maxAttempts, timeout.pause));
 	}
 
 	@Override


### PR DESCRIPTION
- skipping LoadBalancer for failed deployments

- making time to wait for loadBalancer configurable

- adding LoaadBalancer tests

Fixes #12

Resolves spring-cloud/spring-cloud-dataflow-server-kubernetes#66