### PR TITLE
Improve Tests for CI

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -113,8 +113,7 @@ public class KubernetesAppDeployer implements AppDeployer {
 		logger.debug("Undeploying module: {}", appId);
 
 		try {
-			if (!status(appId).getState().equals(DeploymentState.failed) &&
-					"LoadBalancer".equals(client.services().withName(appId).get().getSpec().getType())) {
+			if ("LoadBalancer".equals(client.services().withName(appId).get().getSpec().getType())) {
 				Service svc = client.services().withName(appId).get();
 				int tries = 0;
 				int maxWait = properties.getMinutesToWaitForLoadBalancer() * 6; // we check 6 times per minute

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerProperties.java
@@ -69,7 +69,7 @@ public class KubernetesAppDeployerProperties {
 	/**
 	 * Memory to allocate for a Pod.
 	 */
-	private String memory = "768Mi";
+	private String memory = "512Mi";
 
 	/**
 	 * CPU to allocate for a Pod.

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -69,6 +69,7 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 
 	@Test
 	public void testFailedDeploymentWithLoadBalancer() {
+		log.info("Testing {}...", "FailedDeploymentWithLoadBalancer");
 		KubernetesAppDeployerProperties lbProperties = new KubernetesAppDeployerProperties();
 		lbProperties.setCreateLoadBalancer(true);
 		KubernetesAppDeployer lbAppDeployer = new KubernetesAppDeployer(lbProperties, kubernetesClient, containerFactory);
@@ -95,6 +96,7 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 
 	@Test
 	public void testGoodDeploymentWithLoadBalancer() {
+		log.info("Testing {}...", "GoodDeploymentWithLoadBalancer");
 		KubernetesAppDeployerProperties lbProperties = new KubernetesAppDeployerProperties();
 		lbProperties.setCreateLoadBalancer(true);
 		lbProperties.setMinutesToWaitForLoadBalancer(1);
@@ -115,6 +117,42 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 		lbAppDeployer.undeploy(deploymentId);
 		assertThat(deploymentId, eventually(hasStatusThat(
 				Matchers.<AppStatus>hasProperty("state", is(unknown))), timeout.maxAttempts, timeout.pause));
+	}
+
+	@Override
+	public void testUnknownDeployment() {
+		log.info("Testing {}...", "UnknownDeployment");
+		super.testUnknownDeployment();
+	}
+
+	@Override
+	public void testSimpleDeployment() {
+		log.info("Testing {}...", "SimpleDeployment");
+		super.testSimpleDeployment();
+	}
+
+	@Override
+	public void testRedeploy() {
+		log.info("Testing {}...", "Redeploy");
+		super.testRedeploy();
+	}
+
+	@Override
+	public void testDeployingStateCalculationAndCancel() {
+		log.info("Testing {}...", "DeployingStateCalculationAndCancel");
+		super.testDeployingStateCalculationAndCancel();
+	}
+
+	@Override
+	public void testFailedDeployment() {
+		log.info("Testing {}...", "FailedDeployment");
+		super.testFailedDeployment();
+	}
+
+	@Override
+	public void testParameterPassing() {
+		log.info("Testing {}...", "ParameterPassing");
+		super.testParameterPassing();
 	}
 
 	@Override


### PR DESCRIPTION
- adding logging of test in progress

- removing test for failed deployment when LoadBalancer was created, not needed

- setting memory back to 512Mi, test failures were due to CPU usage, not memory, need to upgrade CI cluster's machine-type to "n1-highcpu-4"

Fixes #14