### PR TITLE
Retrieve app count from environment variables

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -160,7 +160,7 @@ public class KubernetesAppDeployer implements AppDeployer {
 	private ReplicationController createReplicationController(
 			String appId, AppDeploymentRequest request,
 			Map<String, String> idMap, int externalPort) {
-		String countProperty = request.getDefinition().getProperties().get(COUNT_PROPERTY_KEY);
+		String countProperty = request.getEnvironmentProperties().get(COUNT_PROPERTY_KEY);
 		int count = (countProperty != null) ? Integer.parseInt(countProperty) : 1;
 		ReplicationController rc = new ReplicationControllerBuilder()
 				.withNewMetadata()


### PR DESCRIPTION
 - Since deployment request definition wouldn't have the `spring.cloud.deployer.count` property set, we need to retrieve it from environment variable

This resolves #16