### PR TITLE
Modifying the probe configuration

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -45,7 +45,9 @@ public class DefaultContainerFactory implements ContainerFactory {
 
 	private static Logger logger = LoggerFactory.getLogger(DefaultContainerFactory.class);
 
-	private static final String HEALTH_ENDPOINT = "/health";
+	private static final String LIVENESS_ENDPOINT = "/health";
+
+	private static final String READINESS_ENDPOINT = "/info";
 
 	private final KubernetesDeployerProperties properties;
 
@@ -81,11 +83,11 @@ public class DefaultContainerFactory implements ContainerFactory {
 					.withContainerPort(port)
 				.endPort()
 				.withReadinessProbe(
-						createProbe(port, properties.getReadinessProbeTimeout(),
-								properties.getReadinessProbeDelay()))
+						createProbe(port, READINESS_ENDPOINT, properties.getReadinessProbeTimeout(),
+								properties.getReadinessProbeDelay(), properties.getReadinessPeriod()))
 				.withLivenessProbe(
-						createProbe(port, properties.getLivenessProbeTimeout(),
-								properties.getLivenessProbeDelay()));
+						createProbe(port, LIVENESS_ENDPOINT, properties.getLivenessProbeTimeout(),
+								properties.getLivenessProbeDelay(), properties.getLivenessProbePeriod()));
 		}
 		return container.build();
 	}
@@ -93,16 +95,17 @@ public class DefaultContainerFactory implements ContainerFactory {
 	/**
 	 * Create a readiness probe for the /health endpoint exposed by each module.
 	 */
-	protected Probe createProbe(Integer externalPort, int timeout, int initialDelay) {
+	protected Probe createProbe(Integer externalPort, String endpoint, int timeout, int initialDelay, int period) {
 		return new ProbeBuilder()
 			.withHttpGet(
 				new HTTPGetActionBuilder()
-					.withPath(HEALTH_ENDPOINT)
+					.withPath(endpoint)
 					.withNewPort(externalPort)
 					.build()
 			)
 			.withTimeoutSeconds(timeout)
 			.withInitialDelaySeconds(initialDelay)
+			.withPeriodSeconds(period)
 			.build();
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -46,6 +46,12 @@ public class KubernetesDeployerProperties {
 	private int livenessProbeDelay = 10;
 
 	/**
+	 * Period in seconds for performing the Kubernetes liveness check of the app container.
+	 */
+	// See http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	private int livenessProbePeriod = 60;
+
+	/**
 	 * Timeout in seconds for the Kubernetes liveness check of the app container.
 	 * If the health check takes longer than this value to return it is assumed as 'unavailable'.
 	 */
@@ -58,6 +64,12 @@ public class KubernetesDeployerProperties {
 	 */
 	// see http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
 	private int readinessProbeDelay = 10;
+
+	/**
+	 * Period in seconds to perform the readiness check of the app container.
+	 */
+	// see http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	private int readinessPeriod = 10;
 
 	/**
 	 * Timeout in seconds that the app container has to respond to its
@@ -126,6 +138,14 @@ public class KubernetesDeployerProperties {
 		this.livenessProbeDelay = livenessProbeDelay;
 	}
 
+	public int getLivenessProbePeriod() {
+		return livenessProbePeriod;
+	}
+
+	public void setLivenessProbePeriod(int livenessProbePeriod) {
+		this.livenessProbePeriod = livenessProbePeriod;
+	}
+
 	public int getLivenessProbeTimeout() {
 		return livenessProbeTimeout;
 	}
@@ -140,6 +160,14 @@ public class KubernetesDeployerProperties {
 
 	public void setReadinessProbeDelay(int readinessProbeDelay) {
 		this.readinessProbeDelay = readinessProbeDelay;
+	}
+
+	public int getReadinessPeriod() {
+		return readinessPeriod;
+	}
+
+	public void setReadinessPeriod(int readinessPeriod) {
+		this.readinessPeriod = readinessPeriod;
 	}
 
 	public int getReadinessProbeTimeout() {


### PR DESCRIPTION
- using `/info` for readiness probe

- adding properties for setting period for probes with 60s default

- changing initial delay to 30s

Resolves #30