### PR TITLE
Bump kubernetes-client version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # spring-cloud-deployer-kubernetes
+
+## Integration tests
+
+### Minikube
+
+[Minikube](https://github.com/kubernetes/minikube) is a tool that makes it easy to run Kubernetes locally. Minikube runs a single-node Kubernetes cluster inside a VM on your laptop for users looking to try out Kubernetes or develop with it day-to-day.
+
+Follow the instructions for installing Minikube [here](https://github.com/kubernetes/minikube#installation).
+
+#### Running the tests
+
+To run all integration tests against the running Minikube cluster, run
+
+```
+$ ./mvnw test
+```
+
+### Google Container Engine
+
+*TODO*

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<kubernetes-client.version>1.3.83</kubernetes-client.version>
-		<kubernetes-assertions.version>2.2.110</kubernetes-assertions.version>
+		<kubernetes-client.version>1.4.1</kubernetes-client.version>
+		<kubernetes-assertions.version>2.2.148</kubernetes-assertions.version>
 		<spring-cloud-deployer-spi.version>1.0.3.BUILD-SNAPSHOT</spring-cloud-deployer-spi.version>
 	</properties>
 

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -72,13 +72,16 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 		log.info("Testing {}...", "FailedDeploymentWithLoadBalancer");
 		KubernetesDeployerProperties lbProperties = new KubernetesDeployerProperties();
 		lbProperties.setCreateLoadBalancer(true);
+		lbProperties.setLivenessProbePeriod(10);
+		lbProperties.setMaxTerminatedErrorRestarts(1);
+		lbProperties.setMaxCrashLoopBackOffRestarts(1);
 		KubernetesAppDeployer lbAppDeployer = new KubernetesAppDeployer(lbProperties, kubernetesClient, containerFactory);
 
 		AppDefinition definition = new AppDefinition(randomName(), null);
 		Resource resource = integrationTestProcessor();
 		Map<String, String> props = new HashMap<>();
 		// setting to small memory value will cause app to fail to be deployed
-		props.put("spring.cloud.deployer.kubernetes.memory", "128Mi");
+		props.put("spring.cloud.deployer.kubernetes.memory", "8Mi");
 		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, props);
 
 		log.info("Deploying {}...", request.getDefinition().getName());


### PR DESCRIPTION
This addresses #41 by bumping [kubernetes-client to 1.4.1](https://mvnrepository.com/artifact/io.fabric8/kubernetes-client/1.4.1).

Ran all integration tests against a Minikube local instance and all test passed.

Resolves #41