### PR TITLE
add support for liveness and readiness probe path

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -47,10 +47,6 @@ public class DefaultContainerFactory implements ContainerFactory {
 
 	private static Logger logger = LoggerFactory.getLogger(DefaultContainerFactory.class);
 
-	private static final String LIVENESS_ENDPOINT = "/health";
-
-	private static final String READINESS_ENDPOINT = "/info";
-
 	private final KubernetesDeployerProperties properties;
 
 	public DefaultContainerFactory(KubernetesDeployerProperties properties) {
@@ -87,13 +83,13 @@ public class DefaultContainerFactory implements ContainerFactory {
 		if (port != null) {
 			container.addNewPort()
 					.withContainerPort(port)
-				.endPort()
-				.withReadinessProbe(
-						createProbe(port, READINESS_ENDPOINT, properties.getReadinessProbeTimeout(),
-								properties.getReadinessProbeDelay(), properties.getReadinessProbePeriod()))
-				.withLivenessProbe(
-						createProbe(port, LIVENESS_ENDPOINT, properties.getLivenessProbeTimeout(),
-								properties.getLivenessProbeDelay(), properties.getLivenessProbePeriod()));
+					.endPort()
+					.withReadinessProbe(
+							createProbe(port, properties.getReadinessProbePath(), properties.getReadinessProbeTimeout(),
+									properties.getReadinessProbeDelay(), properties.getReadinessProbePeriod()))
+					.withLivenessProbe(
+							createProbe(port, properties.getLivenessProbePath(), properties.getLivenessProbeTimeout(),
+									properties.getLivenessProbeDelay(), properties.getLivenessProbePeriod()));
 		}
 		return container.build();
 	}
@@ -103,16 +99,16 @@ public class DefaultContainerFactory implements ContainerFactory {
 	 */
 	protected Probe createProbe(Integer externalPort, String endpoint, int timeout, int initialDelay, int period) {
 		return new ProbeBuilder()
-			.withHttpGet(
-				new HTTPGetActionBuilder()
-					.withPath(endpoint)
-					.withNewPort(externalPort)
-					.build()
-			)
-			.withTimeoutSeconds(timeout)
-			.withInitialDelaySeconds(initialDelay)
-			.withPeriodSeconds(period)
-			.build();
+				.withHttpGet(
+						new HTTPGetActionBuilder()
+								.withPath(endpoint)
+								.withNewPort(externalPort)
+								.build()
+				)
+				.withTimeoutSeconds(timeout)
+				.withInitialDelaySeconds(initialDelay)
+				.withPeriodSeconds(period)
+				.build();
 	}
 
 	/**

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -59,6 +59,12 @@ public class KubernetesDeployerProperties {
 	private int livenessProbeTimeout = 2;
 
 	/**
+	 * Path that app container has to respond to for liveness check.
+	 */
+	// See http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	private String livenessProbePath = "/health";
+
+	/**
 	 * Delay in seconds when the readiness check of the app container
 	 * should start checking if the module is fully up and running.
 	 */
@@ -77,6 +83,12 @@ public class KubernetesDeployerProperties {
 	 */
 	// see http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
 	private int readinessProbeTimeout = 2;
+
+	/**
+	 * Path that app container has to respond to for readiness check.
+	 */
+	// See http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	private String readinessProbePath = "/info";
 
 	/**
 	 * Memory to allocate for a Pod.
@@ -154,6 +166,14 @@ public class KubernetesDeployerProperties {
 		this.livenessProbeTimeout = livenessProbeTimeout;
 	}
 
+	public String getLivenessProbePath() {
+		return livenessProbePath;
+	}
+
+	public void setLivenessProbePath(String livenessProbePath) {
+		this.livenessProbePath = livenessProbePath;
+	}
+
 	public int getReadinessProbeDelay() {
 		return readinessProbeDelay;
 	}
@@ -176,6 +196,14 @@ public class KubernetesDeployerProperties {
 
 	public void setReadinessProbeTimeout(int readinessProbeTimeout) {
 		this.readinessProbeTimeout = readinessProbeTimeout;
+	}
+
+	public String getReadinessProbePath() {
+		return readinessProbePath;
+	}
+
+	public void setReadinessProbePath(String readinessProbePath) {
+		this.readinessProbePath = readinessProbePath;
 	}
 
 	public String getMemory() {


### PR DESCRIPTION
Currently, liveness and readiness probe path are hardcoded as /health and /info respectively.
This PR adds support for custom for probe paths by extending KubernetesDeployerProperties object.