### PR TITLE
Modifying container args handling

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -119,14 +119,7 @@ public class DefaultContainerFactory implements ContainerFactory {
 	 * Create command arguments
 	 */
 	protected List<String> createCommandArgs(AppDeploymentRequest request) {
-		List<String> cmdArgs = new LinkedList<String>();
-		// add properties from deployment request
-		Map<String, String> args = request.getDefinition().getProperties();
-		for (Map.Entry<String, String> entry : args.entrySet()) {
-			cmdArgs.add(String.format("--%s=%s", entry.getKey(), entry.getValue()));
-		}
-		// add provided command line args
-		cmdArgs.addAll(request.getCommandlineArguments());
+		List<String> cmdArgs = request.getCommandlineArguments();
 		logger.debug("Using command args: " + cmdArgs);
 		return cmdArgs;
 	}


### PR DESCRIPTION
Do not add AppDefinition properties as container args
Current behavior causes issues when a non-default external port is used since server.port property is added as a container argument in DefaultContainerFactory.
Docker is unable to identify this argument thus unable to start container.