### PR TITLE
Allows setting the imagePullPolicy for containers

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -94,4 +94,25 @@ public class AbstractKubernetesDeployer {
 		return limits;
 	}
 
+	/**
+	 * Get the image pull policy for the deployment request. If it is not present use the server default.
+	 *
+	 * @param properties The server properties.
+	 * @param request The deployment request.
+	 * @return The image pull policy to use for the container in the request.
+	 */
+	ImagePullPolicy deduceImagePullPolicy(KubernetesDeployerProperties properties, AppDeploymentRequest request) {
+		String pullPolicyOverride =
+				request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.imagePullPolicy");
+
+		ImagePullPolicy pullPolicy;
+		if (pullPolicyOverride == null) {
+			pullPolicy = properties.getImagePullPolicy();
+		} else {
+			pullPolicy = ImagePullPolicy.valueOf(pullPolicyOverride);
+		}
+		logger.debug("Using imagePullPolicy " + pullPolicy);
+		return pullPolicy;
+	}
+
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ImagePullPolicy.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ImagePullPolicy.java
@@ -1,12 +1,55 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.deployer.spi.kubernetes;
+
+import org.springframework.boot.bind.RelaxedNames;
+
+import java.util.EnumSet;
 
 /**
  * ImagePullPolicy for containers inside a Kubernetes Pod, cf. http://kubernetes.io/docs/user-guide/images/
+ *
+ * @author Moritz Schulze
  */
 public enum ImagePullPolicy {
 
     Always,
     IfNotPresent,
-    Never
+    Never;
+
+    /**
+     * Tries to convert {@code name} to an {@link ImagePullPolicy} by ignoring case, dashes, underscores
+     * and so on like Spring Boot does it in {@link org.springframework.boot.bind.RelaxedConversionService}.
+     *
+     * @param name The name to convert to an {@link ImagePullPolicy}.
+     * @return The {@link ImagePullPolicy} for {@code name} or {@code null} if the conversion was not possible.
+     */
+    public static ImagePullPolicy relaxedValueOf(String name) {
+        for (ImagePullPolicy candidate : EnumSet.allOf(ImagePullPolicy.class)) {
+            for (String relaxedName : new RelaxedNames(candidate.name())) {
+                if (relaxedName.equals(name)) {
+                    return candidate;
+                }
+            }
+            if (candidate.name().equalsIgnoreCase(name)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
 
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ImagePullPolicy.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ImagePullPolicy.java
@@ -1,0 +1,12 @@
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+/**
+ * ImagePullPolicy for containers inside a Kubernetes Pod, cf. http://kubernetes.io/docs/user-guide/images/
+ */
+public enum ImagePullPolicy {
+
+    Always,
+    IfNotPresent,
+    Never
+
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -244,6 +244,8 @@ public class KubernetesAppDeployer extends AbstractKubernetesDeployer implements
 		ResourceRequirements req = new ResourceRequirements();
 		req.setLimits(deduceResourceLimits(properties, request));
 		container.setResources(req);
+		ImagePullPolicy pullPolicy = deduceImagePullPolicy(properties, request);
+		container.setImagePullPolicy(pullPolicy.name());
 
 		podSpec.addToContainers(container);
 		return podSpec.build();

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -125,6 +125,10 @@ public class KubernetesDeployerProperties {
 	 */
 	private int maxCrashLoopBackOffRestarts = 4;
 
+	/**
+	 * The image pull policy to use for Pod deployments in Kubernetes.
+	 */
+	private ImagePullPolicy imagePullPolicy = ImagePullPolicy.Always;
 
 	public String getNamespace() {
 		return namespace;
@@ -260,5 +264,13 @@ public class KubernetesDeployerProperties {
 
 	public void setMaxCrashLoopBackOffRestarts(int maxCrashLoopBackOffRestarts) {
 		this.maxCrashLoopBackOffRestarts = maxCrashLoopBackOffRestarts;
+	}
+
+	public ImagePullPolicy getImagePullPolicy() {
+		return imagePullPolicy;
+	}
+
+	public void setImagePullPolicy(ImagePullPolicy imagePullPolicy) {
+		this.imagePullPolicy = imagePullPolicy;
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -126,6 +126,8 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 		ResourceRequirements req = new ResourceRequirements();
 		req.setLimits(deduceResourceLimits(properties, request));
 		container.setResources(req);
+		ImagePullPolicy pullPolicy = deduceImagePullPolicy(properties, request);
+		container.setImagePullPolicy(pullPolicy.name());
 		return container;
 	}
 

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/ImagePullPolicyTest.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/ImagePullPolicyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit tests for {@link ImagePullPolicy}.
+ *
+ * @author Moritz Schulze
+ */
+public class ImagePullPolicyTest {
+
+    @Test
+    public void relaxedValueOf_ignoresCase() throws Exception {
+        ImagePullPolicy pullPolicy = ImagePullPolicy.relaxedValueOf("aLWays");
+        assertThat(pullPolicy, is(ImagePullPolicy.Always));
+    }
+
+    @Test
+    public void relaxedValueOf_parsesValueWithDashesInsteadOfCamelCase() throws Exception {
+        ImagePullPolicy pullPolicy = ImagePullPolicy.relaxedValueOf("if-not-present");
+        assertThat(pullPolicy, is(ImagePullPolicy.IfNotPresent));
+    }
+
+    @Test
+    public void relaxedValueOf_returnsNullIfValueNotParseable() throws Exception {
+        ImagePullPolicy pullPolicy = ImagePullPolicy.relaxedValueOf("not-a-real-policy");
+        assertThat(pullPolicy, is(nullValue()));
+    }
+}

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerTest.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.core.io.FileSystemResource;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit test for {@link AbstractKubernetesDeployer}.
+ *
+ * @author Moritz Schulze
+ */
+public class KubernetesDeployerTest {
+
+    private AbstractKubernetesDeployer kubernetesDeployer;
+    private AppDeploymentRequest deploymentRequest;
+    private Map<String, String> deploymentProperties;
+    private KubernetesDeployerProperties serverProperties;
+
+    @Before
+    public void setUp() throws Exception {
+        kubernetesDeployer = new AbstractKubernetesDeployer();
+        deploymentProperties = new HashMap<String, String>();
+        deploymentRequest = new AppDeploymentRequest(new AppDefinition("foo", Collections.emptyMap()), new FileSystemResource(""), deploymentProperties);
+        serverProperties = new KubernetesDeployerProperties();
+    }
+
+    @Test
+    public void deduceImagePullPolicy_fallsBackToAlwaysIfOverrideNotParseable() throws Exception {
+        deploymentProperties.put("spring.cloud.deployer.kubernetes.imagePullPolicy", "not-a-real-value");
+        ImagePullPolicy pullPolicy = kubernetesDeployer.deduceImagePullPolicy(serverProperties, deploymentRequest);
+        assertThat(pullPolicy, is(ImagePullPolicy.Always));
+    }
+}


### PR DESCRIPTION
The image pull policy for both apps and tasks can now be set
at deployment time by setting

```
spring.cloud.deployer.kubernetes.imagePullPolicy
```

to one of Always,IfNotPresent,Never for each app/task.

The server can be set up to have a default image pull policy by setting

```
spring.cloud.deployer.kubernetes.imagePullPolicy
```

to one of the given values for the server. The default value is Always.
