### PR TITLE
Allows creating services with NodePort type

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -35,6 +35,7 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
@@ -253,6 +254,12 @@ public class KubernetesAppDeployer extends AbstractKubernetesDeployer implements
 		ServiceSpecBuilder spec = new ServiceSpecBuilder();
 		boolean isCreateLoadBalancer = false;
 		String createLoadBalancer = request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.createLoadBalancer");
+		String createNodePort = request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.createNodePort");
+
+		if (createLoadBalancer != null && createNodePort != null) {
+			throw new IllegalArgumentException("Cannot create NodePort and LoadBalancer at the same time.");
+		}
+
 		if (createLoadBalancer == null) {
 			isCreateLoadBalancer = properties.isCreateLoadBalancer();
 		}
@@ -261,13 +268,28 @@ public class KubernetesAppDeployer extends AbstractKubernetesDeployer implements
 				isCreateLoadBalancer = true;
 			}
 		}
+
 		if (isCreateLoadBalancer) {
 			spec.withType("LoadBalancer");
 		}
+
+		ServicePort servicePort = new ServicePort();
+		servicePort.setPort(externalPort);
+
+		if (createNodePort != null) {
+			spec.withType("NodePort");
+			if (!"true".equals(createNodePort.toLowerCase())) {
+				try {
+					Integer nodePort = Integer.valueOf(createNodePort);
+					servicePort.setNodePort(nodePort);
+				} catch (NumberFormatException e) {
+					throw new IllegalArgumentException(String.format("Invalid value: %s: provided port is not valid.", createNodePort));
+				}
+			}
+		}
+
 		spec.withSelector(idMap)
-				.addNewPort()
-					.withPort(externalPort)
-				.endPort();
+			.addNewPortLike(servicePort).endPort();
 
 		client.services().inNamespace(client.getNamespace()).createNew()
 				.withNewMetadata()


### PR DESCRIPTION
The type of the Kubernetes service can be set to NodePort (similar to LoadBalancer) by
setting

   spring.cloud.deployer.kubernetes.createNodePort

to either "true" or a number at deployment time. The value "true" will choose a
random port. If a number is given it must be in the range that is configured for
the cluster (service-node-port-range, default is 30000-32767).

This setting is useful for private installations of Kubernetes where
using the LoadBalancer type to expose a service is not viable.
