### PR TITLE
Allows separated settings for resource limits and requests for containers

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -77,14 +77,52 @@ public class AbstractKubernetesDeployer {
 		return statusBuilder.build();
 	}
 
+	/**
+	 * Get the resource limits for the deployment request. A Pod can define its maximum needed resources by setting the
+	 * limits and Kubernetes can provide more resources if any are free.
+	 * <p>
+	 * Falls back to the server properties if not present in the deployment request.
+	 * <p>
+	 * Also supports the deprecated properties {@code spring.cloud.deployer.kubernetes.memory/cpu}.
+	 *
+	 * @param properties The server properties.
+	 * @param request    The deployment properties.
+	 */
 	protected Map<String, Quantity> deduceResourceLimits(KubernetesDeployerProperties properties, AppDeploymentRequest request) {
 		String memOverride = request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.memory");
-		if (memOverride == null)
-			memOverride = properties.getMemory();
+		String memLimitsOverride = request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.limits.memory");
+		if (memLimitsOverride != null) {
+			// Non-deprecated value has priority
+			memOverride = memLimitsOverride;
+		}
+
+		// Use server property if there is no request setting
+		if (memOverride == null) {
+			if (properties.getLimits().getMemory() != null) {
+				// Non-deprecated value has priority
+				memOverride = properties.getLimits().getMemory();
+			} else {
+				memOverride = properties.getMemory();
+			}
+		}
+
 
 		String cpuOverride = request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.cpu");
-		if (cpuOverride == null)
-			cpuOverride = properties.getCpu();
+		String cpuLimitsOverride = request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.limits.cpu");
+		if (cpuLimitsOverride != null) {
+			// Non-deprecated value has priority
+			cpuOverride = cpuLimitsOverride;
+		}
+
+		// Use server property if there is no request setting
+		if (cpuOverride == null) {
+			if (properties.getLimits().getCpu() != null) {
+				// Non-deprecated value has priority
+				cpuOverride = properties.getLimits().getCpu();
+			} else {
+				cpuOverride = properties.getCpu();
+			}
+		}
 
 		logger.debug("Using limits - cpu: " + cpuOverride + " mem: " + memOverride);
 
@@ -92,6 +130,33 @@ public class AbstractKubernetesDeployer {
 		limits.put("memory", new Quantity(memOverride));
 		limits.put("cpu", new Quantity(cpuOverride));
 		return limits;
+	}
+
+	/**
+	 * Get the resource requests for the deployment request. Resource requests are guaranteed by the Kubernetes
+	 * runtime.
+	 * Falls back to the server properties if not present in the deployment request.
+	 *
+	 * @param properties The server properties.
+	 * @param request    The deployment properties.
+	 */
+	Map<String, Quantity> deduceResourceRequests(KubernetesDeployerProperties properties, AppDeploymentRequest request) {
+		String memOverride = request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.requests.memory");
+		if (memOverride == null) {
+			memOverride = properties.getRequests().getMemory();
+		}
+
+		String cpuOverride = request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.requests.cpu");
+		if (cpuOverride == null) {
+			cpuOverride = properties.getRequests().getCpu();
+		}
+
+		logger.debug("Using requests - cpu: " + cpuOverride + " mem: " + memOverride);
+
+		Map<String,Quantity> requests = new HashMap<String, Quantity>();
+		requests.put("memory", new Quantity(memOverride));
+		requests.put("cpu", new Quantity(cpuOverride));
+		return requests;
 	}
 
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -243,6 +243,7 @@ public class KubernetesAppDeployer extends AbstractKubernetesDeployer implements
 		// add memory and cpu resource limits
 		ResourceRequirements req = new ResourceRequirements();
 		req.setLimits(deduceResourceLimits(properties, request));
+		req.setRequests(deduceResourceRequests(properties, request));
 		container.setResources(req);
 
 		podSpec.addToContainers(container);

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -25,6 +25,40 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "spring.cloud.deployer.kubernetes")
 public class KubernetesDeployerProperties {
 
+	/**
+	 * Encapsulates resources for Kubernetes Container resource requests and limits
+	 */
+	public static class Resources {
+
+		private String cpu;
+
+		private String memory;
+
+		public Resources() {
+		}
+
+		public Resources(String cpu, String memory) {
+			this.cpu = cpu;
+			this.memory = memory;
+		}
+
+		public String getCpu() {
+			return cpu;
+		}
+
+		public void setCpu(String cpu) {
+			this.cpu = cpu;
+		}
+
+		public String getMemory() {
+			return memory;
+		}
+
+		public void setMemory(String memory) {
+			this.memory = memory;
+		}
+	}
+
 	private static String KUBERNETES_NAMESPACE =
 			System.getenv("KUBERNETES_NAMESPACE") != null ? System.getenv("KUBERNETES_NAMESPACE") : "default";
 
@@ -92,13 +126,29 @@ public class KubernetesDeployerProperties {
 
 	/**
 	 * Memory to allocate for a Pod.
+	 *
+	 * @deprecated Use spring.cloud.deployer.kubernetes.limits.memory
 	 */
+	@Deprecated
 	private String memory = "512Mi";
 
 	/**
 	 * CPU to allocate for a Pod.
+	 *
+	 * @deprecated Use spring.cloud.deployer.kubernetes.limits.cpu
 	 */
+	@Deprecated
 	private String cpu = "500m";
+
+	/**
+	 * Memory and CPU limits (i.e. maximum needed values) to allocate for a Pod.
+	 */
+	private Resources limits = new Resources("500m", "512Mi");
+
+	/**
+	 * Memory and CPU requests (i.e. guaranteed needed values) to allocate for a Pod.
+	 */
+	private Resources requests = new Resources("500m", "512Mi");
 
 	/**
 	 * Environment variables to set for any deployed app container. To be used for service binding.
@@ -124,7 +174,6 @@ public class KubernetesDeployerProperties {
 	 * Maximum allowed restarts for app that is in a CrashLoopBackOff.
 	 */
 	private int maxCrashLoopBackOffRestarts = 4;
-
 
 	public String getNamespace() {
 		return namespace;
@@ -206,18 +255,34 @@ public class KubernetesDeployerProperties {
 		this.readinessProbePath = readinessProbePath;
 	}
 
+	/**
+	 * @deprecated Use {@link #getLimits()}
+	 */
+	@Deprecated
 	public String getMemory() {
 		return memory;
 	}
 
+	/**
+	 * @deprecated Use {@link #setLimits(Resources)}
+	 */
+	@Deprecated
 	public void setMemory(String memory) {
 		this.memory = memory;
 	}
 
+	/**
+	 * @deprecated Use {@link #getLimits()}
+	 */
+	@Deprecated
 	public String getCpu() {
 		return cpu;
 	}
 
+	/**
+	 * @deprecated Use {@link #setLimits(Resources)}
+	 */
+	@Deprecated
 	public void setCpu(String cpu) {
 		this.cpu = cpu;
 	}
@@ -260,5 +325,21 @@ public class KubernetesDeployerProperties {
 
 	public void setMaxCrashLoopBackOffRestarts(int maxCrashLoopBackOffRestarts) {
 		this.maxCrashLoopBackOffRestarts = maxCrashLoopBackOffRestarts;
+	}
+
+	public Resources getLimits() {
+		return limits;
+	}
+
+	public void setLimits(Resources limits) {
+		this.limits = limits;
+	}
+
+	public Resources getRequests() {
+		return requests;
+	}
+
+	public void setRequests(Resources requests) {
+		this.requests = requests;
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -125,6 +125,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 		// add memory and cpu resource limits
 		ResourceRequirements req = new ResourceRequirements();
 		req.setLimits(deduceResourceLimits(properties, request));
+		req.setRequests(deduceResourceRequests(properties, request));
 		container.setResources(req);
 		return container;
 	}

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployerTest.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployerTest.java
@@ -1,0 +1,128 @@
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import io.fabric8.kubernetes.api.model.Quantity;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.core.io.FileSystemResource;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class AbstractKubernetesDeployerTest {
+
+	private AbstractKubernetesDeployer kubernetesDeployer;
+	private AppDeploymentRequest deploymentRequest;
+	private Map<String, String> deploymentProperties;
+	private KubernetesDeployerProperties serverProperties;
+	private KubernetesDeployerProperties.Resources serverLimits;
+	private KubernetesDeployerProperties.Resources serverRequests;
+
+	@Before
+	public void setUp() throws Exception {
+		kubernetesDeployer = new AbstractKubernetesDeployer();
+		deploymentProperties = new HashMap<String, String>();
+		deploymentRequest = new AppDeploymentRequest(new AppDefinition("foo", Collections.emptyMap()), new FileSystemResource(""), deploymentProperties);
+		serverProperties = new KubernetesDeployerProperties();
+		serverLimits = new KubernetesDeployerProperties.Resources();
+		serverProperties.setLimits(serverLimits);
+		serverRequests = new KubernetesDeployerProperties.Resources();
+		serverProperties.setRequests(serverRequests);
+	}
+
+	@Test
+	public void limitCpu_noDeploymentProperty_deprecatedServerProperty_usesServerProperty() throws Exception {
+		serverProperties.setCpu("500m");
+		Map<String, Quantity> limits = kubernetesDeployer.deduceResourceLimits(serverProperties, deploymentRequest);
+		assertThat(limits.get("cpu"), is(new Quantity("500m")));
+	}
+
+	@Test
+	public void limitCpu_noDeploymentProperty_serverProperty_usesServerProperty() throws Exception {
+		serverLimits.setCpu("400m");
+		Map<String, Quantity> limits = kubernetesDeployer.deduceResourceLimits(serverProperties, deploymentRequest);
+		assertThat(limits.get("cpu"), is(new Quantity("400m")));
+	}
+
+	@Test
+	public void limitMemory_noDeploymentProperty_deprecatedServerProperty_usesServerProperty() throws Exception {
+		serverProperties.setMemory("640Mi");
+		Map<String, Quantity> limits = kubernetesDeployer.deduceResourceLimits(serverProperties, deploymentRequest);
+		assertThat(limits.get("memory"), is(new Quantity("640Mi")));
+	}
+
+	@Test
+	public void limitMemory_noDeploymentProperty_serverProperty_usesServerProperty() throws Exception {
+		serverLimits.setMemory("540Mi");
+		Map<String, Quantity> limits = kubernetesDeployer.deduceResourceLimits(serverProperties, deploymentRequest);
+		assertThat(limits.get("memory"), is(new Quantity("540Mi")));
+	}
+
+	@Test
+	public void limitCpu_deploymentProperty_deprecatedKey_usesDeploymentProperty() throws Exception {
+		serverLimits.setCpu("100m");
+		deploymentProperties.put("spring.cloud.deployer.kubernetes.cpu", "300m");
+		Map<String, Quantity> limits = kubernetesDeployer.deduceResourceLimits(serverProperties, deploymentRequest);
+		assertThat(limits.get("cpu"), is(new Quantity("300m")));
+	}
+
+	@Test
+	public void limitCpu_deploymentProperty_usesDeploymentProperty() throws Exception {
+		serverLimits.setCpu("100m");
+		deploymentProperties.put("spring.cloud.deployer.kubernetes.limits.cpu", "400m");
+		Map<String, Quantity> limits = kubernetesDeployer.deduceResourceLimits(serverProperties, deploymentRequest);
+		assertThat(limits.get("cpu"), is(new Quantity("400m")));
+	}
+
+	@Test
+	public void limitMemory_deploymentProperty_deprecatedKey_usesDeploymentProperty() throws Exception {
+		serverLimits.setMemory("640Mi");
+		deploymentProperties.put("spring.cloud.deployer.kubernetes.memory", "1024Mi");
+		Map<String, Quantity> limits = kubernetesDeployer.deduceResourceLimits(serverProperties, deploymentRequest);
+		assertThat(limits.get("memory"), is(new Quantity("1024Mi")));
+	}
+
+	@Test
+	public void limitMemory_deploymentProperty_usesDeploymentProperty() throws Exception {
+		serverLimits.setMemory("640Mi");
+		deploymentProperties.put("spring.cloud.deployer.kubernetes.limits.memory", "256Mi");
+		Map<String, Quantity> limits = kubernetesDeployer.deduceResourceLimits(serverProperties, deploymentRequest);
+		assertThat(limits.get("memory"), is(new Quantity("256Mi")));
+	}
+
+	@Test
+	public void requestCpu_noDeploymentProperty_serverProperty_usesServerProperty() throws Exception {
+		serverRequests.setCpu("400m");
+		Map<String, Quantity> requests = kubernetesDeployer.deduceResourceRequests(serverProperties, deploymentRequest);
+		assertThat(requests.get("cpu"), is(new Quantity("400m")));
+	}
+
+	@Test
+	public void requestMemory_noDeploymentProperty_serverProperty_usesServerProperty() throws Exception {
+		serverRequests.setMemory("120Mi");
+		Map<String, Quantity> requests = kubernetesDeployer.deduceResourceRequests(serverProperties, deploymentRequest);
+		assertThat(requests.get("memory"), is(new Quantity("120Mi")));
+	}
+
+	@Test
+	public void requestCpu_deploymentProperty_usesDeploymentProperty() throws Exception {
+		serverRequests.setCpu("1000m");
+		deploymentProperties.put("spring.cloud.deployer.kubernetes.requests.cpu", "461m");
+		Map<String, Quantity> requests = kubernetesDeployer.deduceResourceRequests(serverProperties, deploymentRequest);
+		assertThat(requests.get("cpu"), is(new Quantity("461m")));
+	}
+
+	@Test
+	public void requestMemory_deploymentProperty_usesDeploymentProperty() throws Exception {
+		serverRequests.setMemory("640Mi");
+		deploymentProperties.put("spring.cloud.deployer.kubernetes.requests.memory", "256Mi");
+		Map<String, Quantity> requests = kubernetesDeployer.deduceResourceRequests(serverProperties, deploymentRequest);
+		assertThat(requests.get("memory"), is(new Quantity("256Mi")));
+	}
+
+}


### PR DESCRIPTION
Adds the possiblity to set Kubernetes resource request values additional
to the resource limits. This allows for creating burstable pods, currently the deployer only supports guaranteed pods.
For more details see [0] and [1].

They can be set serverwide and per deployment request.

The Kubernetes resource limit values get a new key to be set but for
backwards compability the old names are still available (but have lower
priority).

I.e. with this commit the following is possible to allow burstable containers
in Kubernetes:

```
spring.cloud.deployer.kubernetes.requests.cpu=500m
spring.cloud.deployer.kubernetes.requests.memory=640Mi
spring.cloud.deployer.kubernetes.limits.cpu=2000m
# Same as spring.cloud.deployer.kubernetes.cpu=2000m
spring.cloud.deployer.kubernetes.limits.memory=2048Mi
# Same as spring.cloud.deployer.kubernetes.memory=2048Mi
```

[0] https://github.com/kubernetes/kubernetes/blob/release-1.3/docs/design/resource-qos.md
[1] http://kubernetes.io/docs/user-guide/compute-resources/#how-pods-with-resource-requests-are-scheduled
