### PR TITLE
Adds support for specifying entry point style for Docker images

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/EntryPointStyle.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/EntryPointStyle.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+/**
+ * EntryPoint style used for a Docker image. Affects how app properties are passed in.
+ * For exec app properties should be passed in as command line args, for shell they should
+ * be passed in as environment variables and for boot they should be passed in using a
+ * SPRING_APPLICATION_JSON environment variable.
+ *
+ * @author Thomas Risberg
+ * @since 1.1
+ */
+public enum EntryPointStyle {
+
+	exec,
+	shell,
+	boot
+
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -28,8 +28,6 @@ public class KubernetesDeployerProperties {
 	private static String KUBERNETES_NAMESPACE =
 			System.getenv("KUBERNETES_NAMESPACE") != null ? System.getenv("KUBERNETES_NAMESPACE") : "default";
 
-	public static enum DockerEntryPointStyle { EXEC, SHELL, BOOT }
-
 	/**
 	 * Namespace to use.
 	 */
@@ -108,12 +106,9 @@ public class KubernetesDeployerProperties {
 	private String[] environmentVariables = new String[]{};
 
 	/**
-	 * Entry point style used for the Docker image. Affects how app properties are passed in.
-	 * For EXEC app properties will be passed in as command line args, for SHELL they will
-	 * be passed in as environment variables and for BOOT they will be passed in using a
-	 * SPRING_APPLICATION_JSON environment variable.
+	 * Entry point style used for the Docker image. To be used to determine how to pass in properties.
 	 */
-	private DockerEntryPointStyle entryPointStyle = DockerEntryPointStyle.EXEC;
+	private EntryPointStyle entryPointStyle = EntryPointStyle.exec;
 
 	/**
 	 * Create a "LoadBalancer" for the service created for each app. This facilitates assignment of external IP to app.
@@ -240,11 +235,11 @@ public class KubernetesDeployerProperties {
 		this.environmentVariables = environmentVariables;
 	}
 
-	public DockerEntryPointStyle getEntryPointStyle() {
+	public EntryPointStyle getEntryPointStyle() {
 		return entryPointStyle;
 	}
 
-	public void setEntryPointStyle(DockerEntryPointStyle entryPointStyle) {
+	public void setEntryPointStyle(EntryPointStyle entryPointStyle) {
 		this.entryPointStyle = entryPointStyle;
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -28,6 +28,8 @@ public class KubernetesDeployerProperties {
 	private static String KUBERNETES_NAMESPACE =
 			System.getenv("KUBERNETES_NAMESPACE") != null ? System.getenv("KUBERNETES_NAMESPACE") : "default";
 
+	public static enum DockerEntryPointStyle { EXEC, SHELL, BOOT }
+
 	/**
 	 * Namespace to use.
 	 */
@@ -104,6 +106,14 @@ public class KubernetesDeployerProperties {
 	 * Environment variables to set for any deployed app container. To be used for service binding.
 	 */
 	private String[] environmentVariables = new String[]{};
+
+	/**
+	 * Entry point style used for the Docker image. Affects how app properties are passed in.
+	 * For EXEC app properties will be passed in as command line args, for SHELL they will
+	 * be passed in as environment variables and for BOOT they will be passed in using a
+	 * SPRING_APPLICATION_JSON environment variable.
+	 */
+	private DockerEntryPointStyle entryPointStyle = DockerEntryPointStyle.EXEC;
 
 	/**
 	 * Create a "LoadBalancer" for the service created for each app. This facilitates assignment of external IP to app.
@@ -228,6 +238,14 @@ public class KubernetesDeployerProperties {
 
 	public void setEnvironmentVariables(String[] environmentVariables) {
 		this.environmentVariables = environmentVariables;
+	}
+
+	public DockerEntryPointStyle getEntryPointStyle() {
+		return entryPointStyle;
+	}
+
+	public void setEntryPointStyle(DockerEntryPointStyle entryPointStyle) {
+		this.entryPointStyle = entryPointStyle;
 	}
 
 	public boolean isCreateLoadBalancer() {

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTest.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTest.java
@@ -27,26 +27,28 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.core.io.Resource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * Unit tests for {@link DefaultContainerFactory}.
  *
  * @author Will Kennedy
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = { KubernetesAutoConfiguration.class })
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { KubernetesAutoConfiguration.class })
 public class DefaultContainerFactoryTest {
 
 	@Test
@@ -138,6 +140,47 @@ public class DefaultContainerFactoryTest {
 		//Attempting to create with an invalid integer set for a port should cause an exception to bubble up.
         defaultContainerFactory.create("app-test", appDeploymentRequest, null, null);
     }
+
+	@Test
+	public void createWithEntryPointStyle() throws JsonProcessingException {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		DefaultContainerFactory defaultContainerFactory = new DefaultContainerFactory(
+				kubernetesDeployerProperties);
+
+		Map<String, String> appProps = new HashMap<>();
+		appProps.put("foo.bar.baz", "test");
+		AppDefinition definition = new AppDefinition("app-test", appProps);
+		Resource resource = getResource();
+		Map<String, String> props = new HashMap<>();
+
+		props.put("spring.cloud.deployer.kubernetes.entryPointStyle", "shell");
+		AppDeploymentRequest appDeploymentRequestShell = new AppDeploymentRequest(definition,
+				resource, props);
+		Container containerShell = defaultContainerFactory.create("app-test",
+				appDeploymentRequestShell, null, null);
+		assertNotNull(containerShell);
+		assertTrue(containerShell.getEnv().get(0).getName().equals("FOO_BAR_BAZ"));
+		assertTrue(containerShell.getArgs().size() == 0);
+
+		props.put("spring.cloud.deployer.kubernetes.entryPointStyle", "exec");
+		AppDeploymentRequest appDeploymentRequestExec = new AppDeploymentRequest(definition,
+				resource, props);
+		Container containerExec = defaultContainerFactory.create("app-test",
+				appDeploymentRequestExec, null, null);
+		assertNotNull(containerExec);
+		assertTrue(containerExec.getEnv().size() == 0);
+		assertTrue(containerExec.getArgs().get(0).equals("--foo.bar.baz=test"));
+
+		props.put("spring.cloud.deployer.kubernetes.entryPointStyle", "boot");
+		AppDeploymentRequest appDeploymentRequestBoot = new AppDeploymentRequest(definition,
+				resource, props);
+		Container containerBoot = defaultContainerFactory.create("app-test",
+				appDeploymentRequestBoot, null, null);
+		assertNotNull(containerBoot);
+		assertTrue(containerBoot.getEnv().get(0).getName().equals("SPRING_APPLICATION_JSON"));
+		assertTrue(containerBoot.getEnv().get(0).getValue().equals(new ObjectMapper().writeValueAsString(appProps)));
+		assertTrue(containerBoot.getArgs().size() == 0);
+	}
 
 	private Resource getResource() {
 		return new DockerResource(

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -33,7 +33,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
@@ -48,7 +48,7 @@ import org.springframework.core.io.Resource;
  *
  * @author Thomas Risberg
  */
-@SpringApplicationConfiguration(classes = {KubernetesAutoConfiguration.class})
+@SpringBootTest(classes = {KubernetesAutoConfiguration.class})
 public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIntegrationTests {
 
 	@ClassRule

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherIntegrationTests.java
@@ -16,52 +16,29 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.hamcrest.core.Is;
-import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
-import org.springframework.cloud.deployer.spi.core.AppDefinition;
-import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
-import org.springframework.cloud.deployer.spi.task.TaskStatus;
 import org.springframework.cloud.deployer.spi.test.AbstractTaskLauncherIntegrationTests;
 import org.springframework.core.io.Resource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
-import static org.springframework.cloud.deployer.spi.task.LaunchState.complete;
-import static org.springframework.cloud.deployer.spi.task.LaunchState.failed;
-import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
 
 /**
  * Integration tests for {@link KubernetesTaskLauncher}.
  *
  * @author Thomas Risberg
  */
-@SpringApplicationConfiguration(classes = {KubernetesAutoConfiguration.class})
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {KubernetesAutoConfiguration.class})
 public class KubernetesTaskLauncherIntegrationTests extends AbstractTaskLauncherIntegrationTests {
 
 	private static final Log logger = LogFactory.getLog(KubernetesTaskLauncherIntegrationTests.class);


### PR DESCRIPTION
- three styles EXEC (default), SHELL and BOOT
- Affects how app properties are passed in.
  -- for EXEC app properties will be passed in as command line args
  -- for SHELL they will be passed in as environment variables
  -- for BOOT they will be passed in using a SPRING_APPLICATION_JSON environment variable.
- switch to using the newer Spring Boot test annotations

Resolves #65
