### PR TITLE
Added all supported volume types. Fixes #85.

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.hashids.Hashids;
 
 import org.springframework.boot.bind.RelaxedNames;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -228,7 +228,7 @@ public class DefaultContainerFactory implements ContainerFactory {
 						volume.length == 3 ? Boolean.valueOf(volume[2]) : Boolean.FALSE, null));
 			}
 		}
-		properties.getVolumeMounts();
+		volumeMounts.addAll(properties.getVolumeMounts());
 		return new ArrayList<>(volumeMounts);
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -127,7 +127,8 @@ public class DefaultContainerFactory implements ContainerFactory {
 		container.withName(appInstanceId)
 				.withImage(image)
 				.withEnv(envVars)
-				.withArgs(appArgs);
+				.withArgs(appArgs)
+				.withVolumeMounts(getVolumeMounts(request));
 
 		if (port != null) {
 			container.addNewPort()

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -222,7 +222,7 @@ public class DefaultContainerFactory implements ContainerFactory {
 		if (!StringUtils.isEmpty(volumeMountDeploymentProperty)) {
 			String[] volumePairs = volumeMountDeploymentProperty.split(",");
 			for (String volumePair : volumePairs) {
-				String[] volume = volumePair.split(":");
+				String[] volume = volumePair.trim().split(":");
 				Assert.isTrue(volume.length <= 3, format("Invalid volume mount: '{}'", volumePair));
 				volumeMounts.add(new VolumeMount(volume[1], volume[0],
 						volume.length == 3 ? Boolean.valueOf(volume[2]) : Boolean.FALSE, null));

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -250,7 +250,7 @@ public class KubernetesAppDeployer extends AbstractKubernetesDeployer implements
 		ImagePullPolicy pullPolicy = deduceImagePullPolicy(properties, request);
 		container.setImagePullPolicy(pullPolicy.name());
 		// Add volumes and mounts
-		if (properties.getVolumeMounts() != null) {
+		if (properties.getVolumes() != null) {
 			podSpec.withVolumes(properties.getVolumes());
 		}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -201,6 +201,8 @@ public class KubernetesDeployerProperties {
 	/**
 	 * The volumes that a Kubernetes instance supports.
 	 * See http://kubernetes.io/docs/user-guide/volumes/#types-of-volumes
+	 * This can be specified as a deployer property or as an app deployment property.
+	 * Deployment properties will override deployer properties.
 	 */
 	private List<Volume> volumes = new ArrayList<>();
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -16,70 +16,20 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.List;
 
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * @author Florian Rosenberg
  * @author Thomas Risberg
+ * @author Donovan Muller
  */
 @ConfigurationProperties(prefix = "spring.cloud.deployer.kubernetes")
 public class KubernetesDeployerProperties {
-
-	/**
-	 * Encapsulates volumes to be mounted.
-	 */
-	public static class HostVolumeMount {
-
-		private String name;
-
-		private String hostPath;
-
-		private String containerPath;
-
-		private boolean readOnly;
-
-		public HostVolumeMount(String name, String hostPath, String containerPath, boolean readOnly) {
-			this.name = name;
-			this.hostPath = hostPath;
-			this.containerPath = containerPath;
-			this.readOnly = readOnly;
-		}
-
-		public String getName() {
-			return name;
-		}
-
-		public void setName(String mountName) {
-			this.name = mountName;
-		}
-
-		public String getHostPath() {
-			return hostPath;
-		}
-
-		public void setHostPath(String hostPath) {
-			this.hostPath = hostPath;
-		}
-
-		public String getContainerPath() {
-			return containerPath;
-		}
-
-		public void setContainerPath(String containerPath) {
-			this.containerPath = containerPath;
-		}
-
-		public boolean isReadOnly() {
-			return readOnly;
-		}
-
-		public void setReadOnly(boolean readOnly) {
-			this.readOnly = readOnly;
-		}
-
-	}
 
 	/**
 	 * Encapsulates resources for Kubernetes Container resource requests and limits
@@ -241,7 +191,18 @@ public class KubernetesDeployerProperties {
 	 */
 	private ImagePullPolicy imagePullPolicy = ImagePullPolicy.IfNotPresent;
 
-	private Collection<HostVolumeMount> hostVolumeMounts;
+	/**
+	 * Volume mounts that a container is requesting.
+	 * This can be specified as a deployer property or as an app deployment property.
+	 * Deployment properties will override depoyer properties.
+	 */
+	private List<VolumeMount> volumeMounts = new ArrayList<>();
+
+	/**
+	 * The volumes that a Kubernetes instance supports.
+	 * See http://kubernetes.io/docs/user-guide/volumes/#types-of-volumes
+	 */
+	private List<Volume> volumes = new ArrayList<>();
 
 	public String getNamespace() {
 		return namespace;
@@ -410,7 +371,7 @@ public class KubernetesDeployerProperties {
 	public void setImagePullPolicy(ImagePullPolicy imagePullPolicy) {
 		this.imagePullPolicy = imagePullPolicy;
 	}
-		
+
 	public Resources getLimits() {
 		return limits;
 	}
@@ -427,12 +388,19 @@ public class KubernetesDeployerProperties {
 		this.requests = requests;
 	}
 
-	public Collection<HostVolumeMount> getHostVolumeMounts() {
-		return hostVolumeMounts;
+	public List<VolumeMount> getVolumeMounts() {
+		return volumeMounts;
 	}
 
-	public void setHostVolumeMounts(Collection<HostVolumeMount> hostVolumeMounts) {
-		this.hostVolumeMounts = hostVolumeMounts;
+	public void setVolumeMounts(List<VolumeMount> volumeMounts) {
+		this.volumeMounts = volumeMounts;
 	}
 
+	public List<Volume> getVolumes() {
+		return volumes;
+	}
+
+	public void setVolumes(List<Volume> volumes) {
+		this.volumes = volumes;
+	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -194,7 +194,7 @@ public class KubernetesDeployerProperties {
 	/**
 	 * Volume mounts that a container is requesting.
 	 * This can be specified as a deployer property or as an app deployment property.
-	 * Deployment properties will override depoyer properties.
+	 * Deployment properties will override deployer properties.
 	 */
 	private List<VolumeMount> volumeMounts = new ArrayList<>();
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.hashids.Hashids;
 
@@ -51,8 +50,6 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 	private final KubernetesClient client;
 
 	private final ContainerFactory containerFactory;
-
-	private final Map<String, Object> running = new ConcurrentHashMap<>();
 
 	@Autowired
 	public KubernetesTaskLauncher(KubernetesDeployerProperties properties,

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployerTests.java
@@ -37,7 +37,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
  *
  * @author Moritz Schulze
  */
-public class KubernetesDeployerTests {
+public class AbstractKubernetesDeployerTests {
 
 	private AbstractKubernetesDeployer kubernetesDeployer;
 	private AppDeploymentRequest deploymentRequest;
@@ -47,7 +47,7 @@ public class KubernetesDeployerTests {
 	@Before
 	public void setUp() throws Exception {
 		kubernetesDeployer = new AbstractKubernetesDeployer();
-		deploymentProperties = new HashMap<String, String>();
+		deploymentProperties = new HashMap<>();
 		deploymentRequest = new AppDeploymentRequest(new AppDefinition("foo", Collections.emptyMap()), new FileSystemResource(""), deploymentProperties);
 		serverProperties = new KubernetesDeployerProperties();
 	}

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
@@ -185,7 +185,7 @@ public class DefaultContainerFactoryTests {
 
 	@Test
 	public void createWithVolumeMounts() {
-		// test volume defined as deployer properties
+		// test volume mounts defined as deployer properties
 		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
 		DefaultContainerFactory defaultContainerFactory = new DefaultContainerFactory(
 				kubernetesDeployerProperties);
@@ -203,7 +203,7 @@ public class DefaultContainerFactoryTests {
 		assertThat(container.getVolumeMounts()).first()
 				.isEqualTo(new VolumeMount("/test", "test", false, null));
 
-		// test volume defined as app deployment property, overriding the deployer property
+		// test volume mounts defined as app deployment property, overriding the deployer property
 		kubernetesDeployerProperties = new KubernetesDeployerProperties();
 		kubernetesDeployerProperties.setVolumeMounts(
 				Collections.singletonList(new VolumeMount("/test", "test", false, null)));

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
@@ -16,13 +16,12 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -46,6 +46,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Unit tests for {@link DefaultContainerFactory}.
  *
  * @author Will Kennedy
+ * @author Donovan Muller
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { KubernetesAutoConfiguration.class })
@@ -95,7 +96,7 @@ public class DefaultContainerFactoryTests {
 		Container container = defaultContainerFactory.create("app-test",
 				appDeploymentRequest, null, null);
 		assertNotNull(container);
-		assertThat(container.getCommand(), is(Arrays.asList("echo", "arg1", "arg2")));
+		assertThat(container.getCommand()).containsExactly("echo", "arg1", "arg2");
 	}
 
 	@Test
@@ -180,6 +181,42 @@ public class DefaultContainerFactoryTests {
 		assertTrue(containerBoot.getEnv().get(0).getName().equals("SPRING_APPLICATION_JSON"));
 		assertTrue(containerBoot.getEnv().get(0).getValue().equals(new ObjectMapper().writeValueAsString(appProps)));
 		assertTrue(containerBoot.getArgs().size() == 0);
+	}
+
+	@Test
+	public void createWithVolumeMounts() {
+		// test volume defined as deployer properties
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		DefaultContainerFactory defaultContainerFactory = new DefaultContainerFactory(
+				kubernetesDeployerProperties);
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		Resource resource = getResource();
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.volumeMounts", "test:/test");
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition,
+				resource, props);
+
+		Container container = defaultContainerFactory.create("app-test",
+				appDeploymentRequest, null, null);
+
+		assertThat(container.getVolumeMounts()).first()
+				.isEqualTo(new VolumeMount("/test", "test", false, null));
+
+		// test volume defined as app deployment property, overriding the deployer property
+		kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setVolumeMounts(
+				Collections.singletonList(new VolumeMount("/test", "test", false, null)));
+		defaultContainerFactory = new DefaultContainerFactory(
+				kubernetesDeployerProperties);
+
+		props.clear();
+		props.put("spring.cloud.deployer.kubernetes.volumeMounts", "test:/test/overridden:true");
+		container = defaultContainerFactory.create("app-test",
+				appDeploymentRequest, null, null);
+
+		assertThat(container.getVolumeMounts()).first()
+				.isEqualTo(new VolumeMount("/test/overridden", "test", true, null));
 	}
 
 	private Resource getResource() {

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -68,9 +68,6 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 	@Autowired
 	KubernetesClient kubernetesClient;
 
-	@Autowired
-	ContainerFactory containerFactory;
-
 	@Override
 	protected AppDeployer appDeployer() {
 		return appDeployer;
@@ -84,6 +81,7 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 		lbProperties.setLivenessProbePeriod(10);
 		lbProperties.setMaxTerminatedErrorRestarts(1);
 		lbProperties.setMaxCrashLoopBackOffRestarts(1);
+		ContainerFactory containerFactory = new DefaultContainerFactory(lbProperties);
 		KubernetesAppDeployer lbAppDeployer = new KubernetesAppDeployer(lbProperties, kubernetesClient, containerFactory);
 
 		AppDefinition definition = new AppDefinition(randomName(), null);
@@ -112,6 +110,7 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 		KubernetesDeployerProperties lbProperties = new KubernetesDeployerProperties();
 		lbProperties.setCreateLoadBalancer(true);
 		lbProperties.setMinutesToWaitForLoadBalancer(1);
+		ContainerFactory containerFactory = new DefaultContainerFactory(lbProperties);
 		KubernetesAppDeployer lbAppDeployer = new KubernetesAppDeployer(lbProperties, kubernetesClient, containerFactory);
 
 		AppDefinition definition = new AppDefinition(randomName(), null);
@@ -144,6 +143,7 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 				.withName(mountName)
 				.build()));
 		deployProperties.setVolumeMounts(Collections.singletonList(new VolumeMount(hostPath, mountName, false, null)));
+		ContainerFactory containerFactory = new DefaultContainerFactory(deployProperties);
 		KubernetesAppDeployer lbAppDeployer = new KubernetesAppDeployer(deployProperties, kubernetesClient, containerFactory);
 
 		AppDefinition definition = new AppDefinition(randomName(), Collections.singletonMap("logging.file", containerPath + subPath));

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTest.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTest.java
@@ -1,0 +1,53 @@
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.springframework.boot.bind.YamlConfigurationFactory;
+import org.springframework.cloud.deployer.resource.docker.DockerResource;
+import org.springframework.cloud.deployer.spi.core.AppDefinition;
+import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+
+/**
+ * Unit tests for {@link KubernetesAppDeployer}
+ *
+ * @author Donovan Muller
+ */
+public class KubernetesAppDeployerTest {
+
+	private KubernetesAppDeployer deployer;
+
+	@Test
+	public void deployWithHostPathVolume() throws Exception {
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(),
+				new HashMap<>());
+
+		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec("1", appDeploymentRequest, 8080, 1);
+
+		assertThat(podSpec.getVolumes()).containsOnly(
+				new VolumeBuilder().withName("testhostpath").withNewHostPath("/test").build(),
+				new VolumeBuilder().withName("testpvc").withNewPersistentVolumeClaim("testClaim", true).build(),
+				new VolumeBuilder().withName("testnfs").withNewNfs("/test", null, "10.0.0.1:111").build());
+	}
+
+	private Resource getResource() {
+		return new DockerResource("springcloud/spring-cloud-deployer-spi-test-app:latest");
+	}
+
+	private KubernetesDeployerProperties bindDeployerProperties() throws Exception {
+		YamlConfigurationFactory<KubernetesDeployerProperties> yamlConfigurationFactory = new YamlConfigurationFactory<>(
+				KubernetesDeployerProperties.class);
+		yamlConfigurationFactory.setResource(new ClassPathResource("dataflow-server.yml"));
+		yamlConfigurationFactory.afterPropertiesSet();
+		return yamlConfigurationFactory.getObject();
+	}
+}

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/RunAbstractKubernetesDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/RunAbstractKubernetesDeployerTests.java
@@ -37,7 +37,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
  *
  * @author Moritz Schulze
  */
-public class AbstractKubernetesDeployerTests {
+public class RunAbstractKubernetesDeployerTests {
 
 	private AbstractKubernetesDeployer kubernetesDeployer;
 	private AppDeploymentRequest deploymentRequest;

--- a/src/test/resources/dataflow-server.yml
+++ b/src/test/resources/dataflow-server.yml
@@ -2,7 +2,7 @@
 volumes:
   - name: testhostpath
     hostPath:
-      path: /test
+      path: /test/hostPath
 
   - name: testpvc
     persistentVolumeClaim:
@@ -12,4 +12,4 @@ volumes:
   - name: testnfs
     nfs:
       server: 10.0.0.1:111
-      path: /test
+      path: /test/nfs

--- a/src/test/resources/dataflow-server.yml
+++ b/src/test/resources/dataflow-server.yml
@@ -1,0 +1,15 @@
+# spring.cloud.deployer.kubernetes.volumes:
+volumes:
+  - name: testhostpath
+    hostPath:
+      path: /test
+
+  - name: testpvc
+    persistentVolumeClaim:
+      claimName: testClaim
+      readOnly: true
+
+  - name: testnfs
+    nfs:
+      server: 10.0.0.1:111
+      path: /test


### PR DESCRIPTION
This PR adds support for all the supported [volume types](http://kubernetes.io/docs/user-guide/volumes/#types-of-volumes) available in the [kubernetes-model](https://github.com/fabric8io/kubernetes-model).

Volumes can be defined as deployer properties only. The reasoning being that the deinfition of a Volume is generally an administrative concern (especially in the case of `PersistentVolumeClaim` etc.) on a Kubernetes cluster and not something that would be defined per app.

VolumeMounts can be defined as deployer *and* deployment properties. Allowing common volume mounts to be assigned to all apps and at an individual app level (additive).
VolumeMounts defined as deployment properties override those defined as deployer properties. The [format of the volume mounts definition](https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/compare/master...donovanmuller:85-update?expand=1#diff-ac742fc1f690acd37859b18a8bbf479bR204) in deployment properties is up for debate...

See [dataflow-server.yml](https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/compare/master...donovanmuller:85-update?expand=1#diff-0affb8ad59ab41d93c465650a259cc7a) for examples of how the Volumes can be defined as deployer properties.

Note: This PR does not take #84 into account but can be adjusted accordingly.

> The `Volume` and `VolumeMount` properties are the bare kubernetes-model types. I.e. there is no local wrapper class (like [HostVolumeMount](https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/blob/master/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java#L33)) for these concepts. The reason is mainly for the `Volume` type, as creating wrapper classes for all the supported volume types would be tedious and add unnecessary maintenance, keeping them in sync with the kubernetes-model types.

Also some minor cleanup of unused imports and removed some unnecessary syntax due to move to Java 8.