### PR TITLE
Make deduceResourceRequests and deduceImagePullPolicy open for reuse

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -240,7 +240,7 @@ public class AbstractKubernetesDeployer {
 	 * @param request The deployment request.
 	 * @return The image pull policy to use for the container in the request.
 	 */
-	ImagePullPolicy deduceImagePullPolicy(AppDeploymentRequest request) {
+	protected ImagePullPolicy deduceImagePullPolicy(AppDeploymentRequest request) {
 		String pullPolicyOverride =
 				request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.imagePullPolicy");
 
@@ -265,7 +265,7 @@ public class AbstractKubernetesDeployer {
 	 *
 	 * @param request    The deployment properties.
 	 */
-	Map<String, Quantity> deduceResourceRequests(AppDeploymentRequest request) {
+	protected Map<String, Quantity> deduceResourceRequests(AppDeploymentRequest request) {
 		String memOverride = request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.requests.memory");
 		if (memOverride == null) {
 			memOverride = properties.getRequests().getMemory();


### PR DESCRIPTION
The OpenShift deployer being *very* similar to the Kubernetes deployer would benefit from these methods being `protected`, allowing reuse, as the` OpenShiftAppDeployer` extends `KubernetesAppDeployer`. This is consistent with [`deduceResourceLimits`](https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/blob/master/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java#L192) which is currently `protected`.