### PR TITLE
Add support for enabling hostNetwork for pods.

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -319,9 +319,17 @@ public class AbstractKubernetesDeployer {
 	 * @return Whether host networking is requested
 	 */
 	protected boolean getHostNetwork(AppDeploymentRequest request) {
-		String hostNetwork =
+		String hostNetworkOverride =
 				request.getDeploymentProperties().get("spring.cloud.deployer.kubernetes.hostNetwork");
-		return Boolean.valueOf(hostNetwork);
+		boolean hostNetwork;
+		if (StringUtils.isEmpty(hostNetworkOverride)) {
+			hostNetwork = properties.isHostNetwork();
+		}
+		else {
+			hostNetwork = Boolean.valueOf(hostNetworkOverride);
+		}
+		logger.debug("Using hostNetwork " + hostNetwork);
+		return hostNetwork;
 	}
 
 	private String getCommonDeployerMemory(AppDeploymentRequest request) {

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,11 @@ import io.fabric8.kubernetes.api.model.Container;
  * Defines how a Kubernetes {@link Container} is created.
  *
  * @author Florian Rosenberg
+ * @author Thomas Risberg
  */
 public interface ContainerFactory {
 
-	Container create(String appId, AppDeploymentRequest request, Integer externalPort, Integer instanceIndex);
+	Container create(String appId, AppDeploymentRequest request, Integer externalPort, Integer instanceIndex,
+	                 boolean hostNetwork);
 
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,6 +206,15 @@ public class KubernetesDeployerProperties {
 	 */
 	private List<Volume> volumes = new ArrayList<>();
 
+	/**
+	 * The hostNetwork setting for the deployments.
+	 * See https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_podspec
+	 * This can be specified as a deployer property or as an app deployment property.
+	 * Deployment properties will override deployer properties.
+	 */
+	private boolean hostNetwork = false;
+
+
 	public String getNamespace() {
 		return namespace;
 	}
@@ -404,5 +413,13 @@ public class KubernetesDeployerProperties {
 
 	public void setVolumes(List<Volume> volumes) {
 		this.volumes = volumes;
+	}
+
+	public boolean isHostNetwork() {
+		return hostNetwork;
+	}
+
+	public void setHostNetwork(boolean hostNetwork) {
+		this.hostNetwork = hostNetwork;
 	}
 }


### PR DESCRIPTION
- this allows us to deploy a stream using something like:
  stream deploy ticktock --properties "app.time.server.port=8281,app.log.server.port=8282,app.*.spring.cloud.deployer.kubernetes.hostNetwork=true"

- when using "minikube" we can now access the deployed apps on http://192.168.99.100:8281/health and http://192.168.99.100:8282/health respectively

- see https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_podspec

Resolves #99