### PR TITLE
Add configuration-processor as optional dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>io.fabric8</groupId>
 			<artifactId>kubernetes-assertions</artifactId>
 			<version>${kubernetes-assertions.version}</version>


### PR DESCRIPTION
     - For autocompletion of properties in IDE

Resolves #116