### PR TITLE
Deploy as StatefulSet for indexed Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ Now run the tests:
 ```
 $ ./mvnw test
 ```
+
+NOTE: if you get authentication errors, try setting basic auth credentials:
+
+Navigate to your project and cluster on https://console.cloud.google.com/  and click on `show credentials`
+
+```bash
+$export KUBERNETES_AUTH_BASIC_PASSWORD=
+$export KUBERNETES_AUTH_BASIC_USERNAME=
+```
+
+

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/CompositeDeploymentStateResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/CompositeDeploymentStateResolver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *  
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+/**
+ * @author David Turanski
+ **/
+
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+
+class CompositeDeploymentStateResolver implements RunningPhaseDeploymentStateResolver {
+	private final RunningPhaseDeploymentStateResolver[] delegates;
+
+	CompositeDeploymentStateResolver(RunningPhaseDeploymentStateResolver... delegates) {
+		this.delegates = delegates;
+	}
+
+	@Override
+	public DeploymentState resolve(ContainerStatus containerStatus) {
+		for (RunningPhaseDeploymentStateResolver resolver: delegates) {
+			DeploymentState deploymentState = resolver.resolve(containerStatus);
+			if (deploymentState != null) {
+				return deploymentState;
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ContainerFactory.java
@@ -25,10 +25,25 @@ import io.fabric8.kubernetes.api.model.Container;
  *
  * @author Florian Rosenberg
  * @author Thomas Risberg
+ * @author David Turanski
  */
 public interface ContainerFactory {
 
+	/**
+	 * @deprecated use create(String appId, AppDeploymentRequest request, Integer externalPort,boolean hostNetwork).
+	 */
+	@Deprecated
 	Container create(String appId, AppDeploymentRequest request, Integer externalPort, Integer instanceIndex,
 	                 boolean hostNetwork);
+
+	/**
+	 *
+	 * @param appId the application Id
+	 * @param request the {@link AppDeploymentRequest}
+	 * @param externalPort the external port
+	 * @param hostNetwork true if the application should use the host network
+	 * @return a {@link Container}
+	 */
+	Container create(String appId, AppDeploymentRequest request, Integer externalPort, boolean hostNetwork);
 
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -51,6 +51,7 @@ import org.springframework.util.StringUtils;
  * @author Florian Rosenberg
  * @author Thomas Risberg
  * @author Donovan Muller
+ * @author David Turanski
  */
 public class DefaultContainerFactory implements ContainerFactory {
 
@@ -64,7 +65,13 @@ public class DefaultContainerFactory implements ContainerFactory {
 
 	@Override
 	public Container create(String appId, AppDeploymentRequest request, Integer port, Integer instanceIndex,
-	                        boolean hostNetwork) {
+		boolean hostNetwork) {
+		return this.create(appId, request, port, hostNetwork);
+	}
+
+	@Override
+	public Container create(String appId, AppDeploymentRequest request, Integer port, boolean hostNetwork) {
+
 		String image;
 		try {
 			image = request.getResource().getURI().getSchemeSpecificPart();
@@ -119,19 +126,15 @@ public class DefaultContainerFactory implements ContainerFactory {
 			envVars.add(new EnvVar(e.getKey(), e.getValue(), null));
 		}
 		envVars.add(new EnvVar("SPRING_CLOUD_APPLICATION_GUID", "${HOSTNAME}", null));
-		if (instanceIndex != null) {
-			envVars.add(new EnvVar(AppDeployer.INSTANCE_INDEX_PROPERTY_KEY, instanceIndex.toString(), null));
-			envVars.add(new EnvVar("SPRING_APPLICATION_INDEX", instanceIndex.toString(), null));
-		}
+
 		if (request.getDeploymentProperties().get(AppDeployer.GROUP_PROPERTY_KEY) != null) {
 			envVars.add(new EnvVar("SPRING_CLOUD_APPLICATION_GROUP",
 					request.getDeploymentProperties().get(AppDeployer.GROUP_PROPERTY_KEY), null));
 		}
 
-		String appInstanceId = instanceIndex == null ? appId : appId + "-" + instanceIndex;
 
 		ContainerBuilder container = new ContainerBuilder();
-		container.withName(appInstanceId)
+		container.withName(appId)
 				.withImage(image)
 				.withEnv(envVars)
 				.withArgs(appArgs)

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultRunningPhaseDeploymentStateResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultRunningPhaseDeploymentStateResolver.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+
+/**
+ * @author David Turanski
+ **/
+public class DefaultRunningPhaseDeploymentStateResolver extends CompositeDeploymentStateResolver {
+
+	public DefaultRunningPhaseDeploymentStateResolver(KubernetesDeployerProperties properties) {
+		super(
+			new PredicateRunningPhaseDeploymentStateResolver.ContainerReady(properties),
+			new PredicateRunningPhaseDeploymentStateResolver.ContainerCrashed(properties),
+			new PredicateRunningPhaseDeploymentStateResolver.RestartsDueToTheSameError(properties),
+			new PredicateRunningPhaseDeploymentStateResolver.CrashLoopBackOffRestarts(properties),
+			new PredicateRunningPhaseDeploymentStateResolver.ContainerTerminated(properties),
+			//default
+			containerStatus -> DeploymentState.deploying);
+	}
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppInstanceStatus.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppInstanceStatus.java
@@ -16,22 +16,18 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
-
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
-import io.fabric8.kubernetes.api.model.ContainerStatus;
-import io.fabric8.kubernetes.api.model.Pod;
-
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Represents the status of a module.
@@ -47,8 +43,7 @@ public class KubernetesAppInstanceStatus implements AppInstanceStatus {
 	private Service service;
 	private KubernetesDeployerProperties properties;
 	private ContainerStatus containerStatus;
-	private RunningPhaseDeploymentStateResolver runningPhaseDeploymentStateResolver =
-		new DefaultRunningPhaseDeploymentStateResolver();
+	private RunningPhaseDeploymentStateResolver runningPhaseDeploymentStateResolver;
 
 	public KubernetesAppInstanceStatus(Pod pod, Service service, KubernetesDeployerProperties properties) {
 		this.pod = pod;
@@ -57,9 +52,21 @@ public class KubernetesAppInstanceStatus implements AppInstanceStatus {
 		// we assume one container per pod
 		if (pod != null && pod.getStatus().getContainerStatuses().size() == 1) {
 			this.containerStatus = pod.getStatus().getContainerStatuses().get(0);
-		} else {
+		}
+		else {
 			this.containerStatus = null;
 		}
+		this.runningPhaseDeploymentStateResolver = new DefaultRunningPhaseDeploymentStateResolver(properties);
+	}
+
+	/**
+	 * Override the default {@link RunningPhaseDeploymentStateResolver} implementation.
+	 *
+	 * @param runningPhaseDeploymentStateResolver
+	 */
+	public void setRunningPhaseDeploymentStateResolver(
+		RunningPhaseDeploymentStateResolver runningPhaseDeploymentStateResolver) {
+		this.runningPhaseDeploymentStateResolver = runningPhaseDeploymentStateResolver;
 	}
 
 	@Override
@@ -79,25 +86,25 @@ public class KubernetesAppInstanceStatus implements AppInstanceStatus {
 		logger.debug(String.format("%s - Phase [ %s ]", pod.getMetadata().getName(), pod.getStatus().getPhase()));
 		logger.debug(String.format("%s - ContainerStatus [ %s ]", pod.getMetadata().getName(), containerStatus));
 		switch (pod.getStatus().getPhase()) {
-			
-			case "Pending":
-				return DeploymentState.deploying;
-				
-			// We only report a module as running if the container is also ready to service requests.
-			// We also implement the Readiness check as part of the container to ensure ready means
-			// that the module is up and running and not only that the JVM has been created and the
-			// Spring module is still starting up
-			case "Running":
-				// we assume we only have one container
-				return runningPhaseDeploymentStateResolver.resolve(containerStatus);
-			case "Failed":
-				return DeploymentState.failed;
 
-			case "Unknown":
-				return DeploymentState.unknown;
+		case "Pending":
+			return DeploymentState.deploying;
 
-			default: 
-				return DeploymentState.unknown;
+		// We only report a module as running if the container is also ready to service requests.
+		// We also implement the Readiness check as part of the container to ensure ready means
+		// that the module is up and running and not only that the JVM has been created and the
+		// Spring module is still starting up
+		case "Running":
+			// we assume we only have one container
+			return runningPhaseDeploymentStateResolver.resolve(containerStatus);
+		case "Failed":
+			return DeploymentState.failed;
+
+		case "Unknown":
+			return DeploymentState.unknown;
+
+		default:
+			return DeploymentState.unknown;
 		}
 	}
 
@@ -112,16 +119,16 @@ public class KubernetesAppInstanceStatus implements AppInstanceStatus {
 			result.put("host.ip", pod.getStatus().getHostIP());
 			result.put("phase", pod.getStatus().getPhase());
 			result.put(AbstractKubernetesDeployer.SPRING_APP_KEY.replace('-', '.'),
-					pod.getMetadata().getLabels().get(AbstractKubernetesDeployer.SPRING_APP_KEY));
+				pod.getMetadata().getLabels().get(AbstractKubernetesDeployer.SPRING_APP_KEY));
 			result.put(AbstractKubernetesDeployer.SPRING_DEPLOYMENT_KEY.replace('-', '.'),
-					pod.getMetadata().getLabels().get(AbstractKubernetesDeployer.SPRING_DEPLOYMENT_KEY));
+				pod.getMetadata().getLabels().get(AbstractKubernetesDeployer.SPRING_DEPLOYMENT_KEY));
 		}
 		if (service != null) {
 			result.put("service.name", service.getMetadata().getName());
 			if ("LoadBalancer".equals(service.getSpec().getType())) {
-				if (service.getStatus() != null && service.getStatus().getLoadBalancer() != null &&
-						service.getStatus().getLoadBalancer().getIngress() != null &&
-						!service.getStatus().getLoadBalancer().getIngress().isEmpty()) {
+				if (service.getStatus() != null && service.getStatus().getLoadBalancer() != null
+					&& service.getStatus().getLoadBalancer().getIngress() != null && !service.getStatus()
+					.getLoadBalancer().getIngress().isEmpty()) {
 					String externalIp = service.getStatus().getLoadBalancer().getIngress().get(0).getIp();
 					result.put("service.external.ip", externalIp);
 					List<ServicePort> ports = service.getSpec().getPorts();
@@ -140,213 +147,22 @@ public class KubernetesAppInstanceStatus implements AppInstanceStatus {
 		if (containerStatus != null) {
 			result.put("container.restartCount", "" + containerStatus.getRestartCount());
 			if (containerStatus.getLastState() != null && containerStatus.getLastState().getTerminated() != null) {
-				result.put("container.lastState.terminated.exitCode", "" + containerStatus.getLastState().getTerminated().getExitCode());
-				result.put("container.lastState.terminated.reason", containerStatus.getLastState().getTerminated().getReason());
+				result.put("container.lastState.terminated.exitCode",
+					"" + containerStatus.getLastState().getTerminated().getExitCode());
+				result.put("container.lastState.terminated.reason",
+					containerStatus.getLastState().getTerminated().getReason());
 			}
 			if (containerStatus.getState() != null && containerStatus.getState().getTerminated() != null) {
-				result.put("container.state.terminated.exitCode", "" + containerStatus.getState().getTerminated().getExitCode());
+				result.put("container.state.terminated.exitCode",
+					"" + containerStatus.getState().getTerminated().getExitCode());
 				result.put("container.state.terminated.reason", containerStatus.getState().getTerminated().getReason());
 			}
 		}
 		return result;
 	}
-
-	static interface RunningPhaseDeploymentStateResolver {
-		DeploymentState resolve(ContainerStatus containerStatus);
-	}
-
-	abstract class ContainerStatusCondition implements Predicate<ContainerStatus> {
-		private final String description;
-
-		ContainerStatusCondition(String description) {
-			this.description = description;
-		}
-		public String toString() {
-			String className = this.getClass().getName();
-
-			return className.substring(className.lastIndexOf(".") + 1) + ":" + description;
-		}
-	}
-
-	/**
-	 *
-	 */
-	class PredicateRunningPhaseDeploymentStateResolver implements RunningPhaseDeploymentStateResolver {
-		private final ContainerStatusCondition[] conditions;
-		private final DeploymentState resolvedState;
-
-		PredicateRunningPhaseDeploymentStateResolver(DeploymentState
-			resolvedState, ContainerStatusCondition... conditions) {
-			this.conditions = conditions;
-			this.resolvedState = resolvedState;
-		}
-
-		public DeploymentState resolve(ContainerStatus containerStatus) {
-
-			Stream<Predicate<ContainerStatus>> conditionsStream = Stream.of(conditions);
-			Boolean allConditionsMet = conditionsStream.reduce((x, y) -> x.and(y)).get().test(containerStatus);
-
-			if (allConditionsMet) {
-				logger.debug("deployment state is " + resolvedState.name());
-				return this.resolvedState;
-			}
-			else {
-				Stream<ContainerStatusCondition> report = Stream.of(conditions);
-				report.filter(c -> {
-					boolean result= false;
-					try {
-						result = c.test(containerStatus);
-					}
-					catch (NullPointerException e) {
-
-					}
-					return !result;
-
-				}).forEach(c -> logger.debug(c + " is not satisfied"));
-
-			}
-			return null;
-		}
-	}
-
-	/**
-	 *
-	 */
-	class CompositeContainerDeploymentStateResolver implements RunningPhaseDeploymentStateResolver {
-		private final RunningPhaseDeploymentStateResolver[] delegates;
-
-		CompositeContainerDeploymentStateResolver(RunningPhaseDeploymentStateResolver... delegates) {
-			this.delegates = delegates;
-		}
-
-		@Override
-		public DeploymentState resolve(ContainerStatus containerStatus) {
-			for (RunningPhaseDeploymentStateResolver resolver: delegates) {
-				DeploymentState deploymentState = resolver.resolve(containerStatus);
-				if (deploymentState != null) {
-					return deploymentState;
-				}
-			}
-			return null;
-		}
-	}
-
-	class DefaultRunningPhaseDeploymentStateResolver extends CompositeContainerDeploymentStateResolver {
-
-		DefaultRunningPhaseDeploymentStateResolver() {
-			super(
-				new ContainerReady(),
-				new ContainerCrashed(),
-				new RestartsDueToTheSameError(),
-				new CrashLoopBackOffRestarts(),
-				new ContainerTerminated(),
-				//default
-				containerStatus -> DeploymentState.deploying);
-		}
-	}
-
-	class ContainerReady extends PredicateRunningPhaseDeploymentStateResolver {
-		ContainerReady() {
-			super(DeploymentState.deployed, new ContainerStatusCondition("container ready") {
-				@Override
-				public boolean test(ContainerStatus containerStatus) {
-					return containerStatus.getReady();
-				}
-			});
-		}
-	}
-
-	class ContainerCrashed extends PredicateRunningPhaseDeploymentStateResolver {
-		ContainerCrashed() {
-			super(DeploymentState.failed,
-				new ContainerStatusCondition("restart count > maxTerminatedErrorRestarts") {
-					@Override
-					public boolean test(ContainerStatus containerStatus) {
-						return containerStatus.getRestartCount() > properties.getMaxTerminatedErrorRestarts();
-					}
-			}, new ContainerStatusCondition("exit code in (1, 137, 143)") {
-					@Override
-					public boolean test(ContainerStatus containerStatus) {
-					// if we are being killed repeatedly due to OOM or using too much CPU, or abnormal termination.
-						return
-							containerStatus.getLastState() != null &&
-							containerStatus.getLastState().getTerminated() != null &&
-							(containerStatus.getLastState().getTerminated().getExitCode() == 137 ||
-							containerStatus.getLastState().getTerminated().getExitCode() == 143 ||
-							containerStatus.getLastState().getTerminated().getExitCode() == 1);
-					}
-				});
-		}
-	}
-
-	// if we are being restarted repeatedly due to the same error, consider the app crashed
-	class RestartsDueToTheSameError extends PredicateRunningPhaseDeploymentStateResolver {
-
-		RestartsDueToTheSameError() {
-			super(DeploymentState.failed, new ContainerStatusCondition("restart count > maxTerminatedErrorRestarts") {
-				@Override
-				public boolean test(ContainerStatus containerStatus) {
-					return containerStatus.getRestartCount() > properties.getMaxTerminatedErrorRestarts();
-				}
-			}, new ContainerStatusCondition("last state termination reason == 'Error' and termination reason == "
-				+ "'Error'") {
-				public boolean test(ContainerStatus containerStatus) {
-					return
-						containerStatus.getLastState() != null && containerStatus.getState() != null &&
-						containerStatus.getLastState().getTerminated() != null &&
-						containerStatus.getLastState().getTerminated().getReason() != null &&
-						containerStatus.getLastState().getTerminated().getReason().contains("Error") &&
-						containerStatus.getState().getTerminated() != null &&
-						containerStatus.getState().getTerminated().getReason() != null &&
-						containerStatus.getState().getTerminated().getReason().contains("Error");
-				}
-			}, new ContainerStatusCondition("last state exit code == exit code") {
-				@Override
-				public boolean test(ContainerStatus containerStatus) {
-					return containerStatus.getLastState().getTerminated().getExitCode().equals(
-						containerStatus.getState().getTerminated().getExitCode());
-				}
-			});
-		}
-	}
-
-	class CrashLoopBackOffRestarts extends PredicateRunningPhaseDeploymentStateResolver {
-		CrashLoopBackOffRestarts() {
-			super(DeploymentState.failed, new ContainerStatusCondition("restart count > CrashLoopBackOffRestarts") {
-				@Override
-				public boolean test(ContainerStatus containerStatus) {
-					return containerStatus.getRestartCount() > properties.getMaxCrashLoopBackOffRestarts();
-				}
-			}, new ContainerStatusCondition("waiting in CrashLoopBackOff") {
-				@Override
-				public boolean test(ContainerStatus containerStatus) {
-					return
-						containerStatus.getLastState() != null &&
-						containerStatus.getState() != null &&
-						containerStatus.getLastState().getTerminated() != null &&
-						containerStatus.getState().getWaiting() != null &&
-						containerStatus.getState().getWaiting().getReason() != null &&
-						containerStatus.getState().getWaiting().getReason().contains("CrashLoopBackOff");
-				}
-			});
-		}
-	}
-
-	class ContainerTerminated extends PredicateRunningPhaseDeploymentStateResolver {
-
-		ContainerTerminated() {
-			super(DeploymentState.undeployed, new ContainerStatusCondition("restart count == 0") {
-				@Override
-				public boolean test(ContainerStatus containerStatus) {
-					return containerStatus.getRestartCount() == 0;
-				}
-			}, new ContainerStatusCondition("state is terminated") {
-				@Override
-				public boolean test(ContainerStatus containerStatus) {
-					return containerStatus.getState() != null &&
-						containerStatus.getState().getTerminated() != null;
-				}
-			});
-		}
-	}
 }
+
+
+
+
+

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -228,7 +228,7 @@ public class KubernetesDeployerProperties {
 	 * Create a "Deployment" with a "Replica Set" instead of a "Replication Controller".
 	 * See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 	 */
-	private boolean createDeployment = false;
+	private boolean createDeployment = true;
 
 
 	public String getNamespace() {
@@ -447,10 +447,20 @@ public class KubernetesDeployerProperties {
 		this.hostNetwork = hostNetwork;
 	}
 
+	/**
+	 * @deprecated as of 1.3. This property is true by default and will not be an option in future releases.
+	 * @return
+	 */
+	@Deprecated
 	public boolean isCreateDeployment() {
 		return createDeployment;
 	}
 
+	/**
+	 * @deprecated as of 1.3.  This property is true by default and will not be an option in future releases.
+	 * @param createDeployment
+	 */
+	@Deprecated
 	public void setCreateDeployment(boolean createDeployment) {
 		this.createDeployment = createDeployment;
 	}

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesHttpClient.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesHttpClient.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import io.fabric8.kubernetes.client.BaseClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.IOException;
+
+/**
+ * Wraps the {@link KubernetesClient} http client to send raw REST requests
+ * @author David Turanski
+ **/
+class KubernetesHttpClient {
+
+	private static final Log logger = LogFactory.getLog(KubernetesHttpClient.class);
+	private final OkHttpClient client;
+	private final String masterUrl;
+
+
+	KubernetesHttpClient(KubernetesClient client) {
+		this.client = ((BaseClient)client).getHttpClient();
+		this.masterUrl = client.getMasterUrl().toString();
+	}
+
+	public Response post(String resourceEndpoint, String json) {
+
+		String url = this.masterUrl + resourceEndpoint;
+
+		logger.debug("Posting to " + url);
+
+		Request post = new Request.Builder().post(RequestBody.create(MediaType.parse("application/json"), json))
+			.url(url).build();
+
+		Response response = execute((this.client.newCall(post)));
+		response.close();
+		return response;
+	}
+
+	public Response get(String resourceEndpoint, String appId) {
+		String url = this.masterUrl + resourceEndpoint + "/" + appId;
+		logger.debug("Getting " + url);
+
+		Request get =  new Request.Builder().get().url(url).build();
+		return execute((this.client.newCall(get)));
+	}
+
+	public Response delete(String resourceEndpoint, String appId) {
+		String url = this.masterUrl + resourceEndpoint + "/" + appId;
+
+		logger.debug("Deleting " + url);
+
+		Request delete = new Request.Builder().delete().url(url).build();
+
+		Response response = execute((this.client.newCall(delete)));
+		response.close();
+		return response;
+	}
+
+	private Response execute(Call call) {
+		Response response;
+		try {
+			response = call.execute();
+			logger.debug("Response code: " + response.code());
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+		return response;
+	}
+
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -41,6 +41,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
  * A task launcher that targets Kubernetes.
  *
  * @author Thomas Risberg
+ * @author David Turanski
  */
 public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implements TaskLauncher {
 
@@ -65,7 +66,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 		if (!status.getState().equals(LaunchState.unknown)) {
 			throw new IllegalStateException("Task " + appId + " already exists with a state of " + status);
 		}
-		Map<String, String> idMap = createIdMap(appId, request, null);
+		Map<String, String> idMap = createIdMap(appId, request);
 
 		logger.debug(String.format("Launching pod for task: %s", appId));
 		try {
@@ -123,7 +124,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 		Map<String, String> podLabelMap = new HashMap<>();
 		podLabelMap.put("task-name", request.getDefinition().getName());
 		podLabelMap.put(SPRING_MARKER_KEY, SPRING_MARKER_VALUE);
-		PodSpec spec = createPodSpec(appId, request, null, null, true);
+		PodSpec spec = createPodSpec(appId, request, null, true);
 		client.pods()
 				.inNamespace(client.getNamespace()).createNew()
 				.withNewMetadata()

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/PredicateRunningPhaseDeploymentStateResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/PredicateRunningPhaseDeploymentStateResolver.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+/**
+ * @author David Turanski
+ **/
+
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+
+public class PredicateRunningPhaseDeploymentStateResolver implements RunningPhaseDeploymentStateResolver {
+	private static Log logger = LogFactory.getLog(PredicateRunningPhaseDeploymentStateResolver.class);
+	private final ContainerStatusCondition[] conditions;
+	private final DeploymentState resolvedState;
+	protected final KubernetesDeployerProperties properties;
+
+	PredicateRunningPhaseDeploymentStateResolver(
+		KubernetesDeployerProperties properties,
+		DeploymentState resolvedState,
+		ContainerStatusCondition... conditions) {
+		this.conditions = conditions;
+		this.resolvedState = resolvedState;
+		this.properties = properties;
+	}
+
+	public DeploymentState resolve(ContainerStatus containerStatus) {
+
+		Stream<Predicate<ContainerStatus>> conditionsStream = Stream.of(conditions);
+		Boolean allConditionsMet = conditionsStream.reduce((x, y) -> x.and(y)).get().test(containerStatus);
+
+		if (allConditionsMet) {
+			logger.debug("deployment state is " + resolvedState.name());
+			return this.resolvedState;
+		}
+		else {
+			Stream<ContainerStatusCondition> report = Stream.of(conditions);
+			report.filter(c -> {
+				boolean result= false;
+				try {
+					result = c.test(containerStatus);
+				}
+				catch (NullPointerException e) {
+
+				}
+				return !result;
+
+			}).forEach(c -> logger.debug(c + " is not satisfied"));
+
+		}
+		return null;
+	}
+
+	static abstract class ContainerStatusCondition implements Predicate<ContainerStatus> {
+		private final String description;
+
+		ContainerStatusCondition(String description) {
+			this.description = description;
+		}
+		public String toString() {
+			String className = this.getClass().getName();
+
+			return className.substring(className.lastIndexOf(".") + 1) + ":" + description;
+		}
+	}
+
+	static class ContainerReady extends PredicateRunningPhaseDeploymentStateResolver {
+		ContainerReady(KubernetesDeployerProperties properties) {
+			super(properties, DeploymentState.deployed, new ContainerStatusCondition("container ready") {
+				@Override
+				public boolean test(ContainerStatus containerStatus) {
+					return containerStatus.getReady();
+				}
+			});
+		}
+	}
+
+	static class ContainerCrashed extends PredicateRunningPhaseDeploymentStateResolver {
+		ContainerCrashed(KubernetesDeployerProperties properties) {
+			super(properties,
+				DeploymentState.failed,
+				new ContainerStatusCondition("restart count > maxTerminatedErrorRestarts") {
+					@Override
+					public boolean test(ContainerStatus containerStatus) {
+						return containerStatus.getRestartCount() > properties.getMaxTerminatedErrorRestarts();
+					}
+				}, new ContainerStatusCondition("exit code in (1, 137, 143)") {
+					@Override
+					public boolean test(ContainerStatus containerStatus) {
+						// if we are being killed repeatedly due to OOM or using too much CPU, or abnormal termination.
+						return
+							containerStatus.getLastState() != null &&
+								containerStatus.getLastState().getTerminated() != null &&
+								(containerStatus.getLastState().getTerminated().getExitCode() == 137 ||
+									containerStatus.getLastState().getTerminated().getExitCode() == 143 ||
+									containerStatus.getLastState().getTerminated().getExitCode() == 1);
+					}
+				});
+		}
+	}
+
+	// if we are being restarted repeatedly due to the same error, consider the app crashed
+	static class RestartsDueToTheSameError extends PredicateRunningPhaseDeploymentStateResolver {
+
+		RestartsDueToTheSameError(KubernetesDeployerProperties properties) {
+			super(properties, DeploymentState.failed, new ContainerStatusCondition("restart count > "
+				+ "maxTerminatedErrorRestarts") {
+				@Override
+				public boolean test(ContainerStatus containerStatus) {
+					return containerStatus.getRestartCount() > properties.getMaxTerminatedErrorRestarts();
+				}
+			}, new ContainerStatusCondition("last state termination reason == 'Error' and termination reason == "
+				+ "'Error'") {
+				public boolean test(ContainerStatus containerStatus) {
+					return
+						containerStatus.getLastState() != null && containerStatus.getState() != null &&
+							containerStatus.getLastState().getTerminated() != null &&
+							containerStatus.getLastState().getTerminated().getReason() != null &&
+							containerStatus.getLastState().getTerminated().getReason().contains("Error") &&
+							containerStatus.getState().getTerminated() != null &&
+							containerStatus.getState().getTerminated().getReason() != null &&
+							containerStatus.getState().getTerminated().getReason().contains("Error");
+				}
+			}, new ContainerStatusCondition("last state exit code == exit code") {
+				@Override
+				public boolean test(ContainerStatus containerStatus) {
+					return containerStatus.getLastState().getTerminated().getExitCode().equals(
+						containerStatus.getState().getTerminated().getExitCode());
+				}
+			});
+		}
+	}
+
+	static class CrashLoopBackOffRestarts extends PredicateRunningPhaseDeploymentStateResolver {
+		CrashLoopBackOffRestarts(KubernetesDeployerProperties properties) {
+			super(properties, DeploymentState.failed, new ContainerStatusCondition("restart count > "
+				+ "CrashLoopBackOffRestarts") {
+				@Override
+				public boolean test(ContainerStatus containerStatus) {
+					return containerStatus.getRestartCount() > properties.getMaxCrashLoopBackOffRestarts();
+				}
+			}, new ContainerStatusCondition("waiting in CrashLoopBackOff") {
+				@Override
+				public boolean test(ContainerStatus containerStatus) {
+					return
+						containerStatus.getLastState() != null &&
+							containerStatus.getState() != null &&
+							containerStatus.getLastState().getTerminated() != null &&
+							containerStatus.getState().getWaiting() != null &&
+							containerStatus.getState().getWaiting().getReason() != null &&
+							containerStatus.getState().getWaiting().getReason().contains("CrashLoopBackOff");
+				}
+			});
+		}
+	}
+
+	static class ContainerTerminated extends PredicateRunningPhaseDeploymentStateResolver {
+
+		ContainerTerminated(KubernetesDeployerProperties properties) {
+			super(properties, DeploymentState.undeployed, new ContainerStatusCondition("restart count == 0") {
+				@Override
+				public boolean test(ContainerStatus containerStatus) {
+					return containerStatus.getRestartCount() == 0;
+				}
+			}, new ContainerStatusCondition("state is terminated") {
+				@Override
+				public boolean test(ContainerStatus containerStatus) {
+					return containerStatus.getState() != null &&
+						containerStatus.getState().getTerminated() != null;
+				}
+			});
+		}
+	}
+}
+

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/RunningPhaseDeploymentStateResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/RunningPhaseDeploymentStateResolver.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+
+/**
+ * @author David Turanski
+ **/
+public interface RunningPhaseDeploymentStateResolver {
+	DeploymentState resolve(ContainerStatus containerStatus);
+}

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -339,7 +339,7 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 
 	@Override
 	protected Timeout deploymentTimeout() {
-		return new Timeout(60, 5000);
+		return new Timeout(300, 2000);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -18,22 +18,19 @@ package org.springframework.cloud.deployer.spi.kubernetes;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.springframework.cloud.deployer.spi.app.DeploymentState.deployed;
 import static org.springframework.cloud.deployer.spi.app.DeploymentState.failed;
 import static org.springframework.cloud.deployer.spi.app.DeploymentState.unknown;
 import static org.springframework.cloud.deployer.spi.kubernetes.AbstractKubernetesDeployer.SPRING_APP_KEY;
 import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HostPathVolumeSource;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
@@ -44,7 +41,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.ClassRule;
 import org.junit.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
@@ -55,14 +51,24 @@ import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.test.AbstractAppDeployerIntegrationTests;
 import org.springframework.cloud.deployer.spi.test.Timeout;
 import org.springframework.core.io.Resource;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Integration tests for {@link KubernetesAppDeployer}.
  *
  * @author Thomas Risberg
  * @author Donovan Muller
+ * @Author David Turanski
  */
-@SpringBootTest(classes = {KubernetesAutoConfiguration.class})
+@SpringBootTest(classes = {KubernetesAutoConfiguration.class}, properties = {
+	"logging.level.org.springframework.cloud.deployer.spi=INFO"
+})
 public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIntegrationTests {
 
 	@ClassRule
@@ -226,19 +232,80 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 				Matchers.hasProperty("state", is(unknown))), timeout.maxAttempts, timeout.pause));
 	}
 
+
+	private void verifyAppEnv(String appId) {
+		String ip="";
+		int port = 0;
+
+		KubernetesDeployerProperties properties = new KubernetesDeployerProperties();
+		boolean success = false;
+
+		Service svc = kubernetesClient.services().withName(appId).get();
+
+		if (svc != null && "LoadBalancer".equals(svc.getSpec().getType())) {
+			int tries = 0;
+			int maxWait = properties.getMinutesToWaitForLoadBalancer() * 6; // we check 6 times per minute
+			while (tries++ < maxWait && !success) {
+				if (svc.getStatus() != null && svc.getStatus().getLoadBalancer() != null &&
+					svc.getStatus().getLoadBalancer().getIngress() != null &&
+					!(svc.getStatus().getLoadBalancer().getIngress().isEmpty())) {
+					ip = svc.getStatus().getLoadBalancer().getIngress().get(0).getIp();
+					port = svc.getSpec().getPorts().get(0).getPort();
+					success = true;
+				}
+				else {
+					try {
+						Thread.sleep(5000L);
+					}
+					catch (InterruptedException e) {
+					}
+					svc = kubernetesClient.services().withName(appId).get();
+				}
+			}
+			log.debug(String.format("LoadBalancer Ingress: %s",
+				svc.getStatus().getLoadBalancer().getIngress().toString()));
+		}
+
+		if (!success) {
+			fail("cannot get service information for " + appId);
+		}
+
+
+
+		String url = String.format("http://%s:%d/env",ip,port);
+
+		log.debug("getting app environment from " + url);
+		RestTemplate restTemplate = new RestTemplate();
+		HashMap<String,Object> env = restTemplate.getForObject(url, HashMap.class);
+
+		Map<String,String> systemEnvironment = (Map)env.get("systemEnvironment");
+		Map<String,String> applicationConfig = (Map)env.get(
+			"applicationConfig: [file:./config/application.properties]");
+
+		String hostName = systemEnvironment.get("HOSTNAME");
+		String expectedIndex =hostName.substring(hostName.lastIndexOf("-")+1);
+		String actualIndex = applicationConfig.get("INSTANCE_INDEX");
+		assertEquals(actualIndex,expectedIndex);
+	}
+
 	@Test
 	public void testDeploymentWithGroupAndIndex() throws IOException {
 		log.info("Testing {}...", "DeploymentWithWithGroupAndIndex");
 		KubernetesDeployerProperties deployProperties = new KubernetesDeployerProperties();
-		deployProperties.setCreateDeployment(originalProperties.isCreateDeployment());
+		deployProperties.setCreateLoadBalancer(true);
+		deployProperties.setMinutesToWaitForLoadBalancer(1);
 		ContainerFactory containerFactory = new DefaultContainerFactory(deployProperties);
 		KubernetesAppDeployer testAppDeployer = new KubernetesAppDeployer(deployProperties, kubernetesClient, containerFactory);
 
-		AppDefinition definition = new AppDefinition(randomName(), new HashMap<>());
+		Map<String,String> appProperties = new  HashMap<>();
+		appProperties.put("security.basic.enabled","false");
+		appProperties.put("management.security.enabled","false");
+		AppDefinition definition = new AppDefinition(randomName(), appProperties);
 		Resource resource = testApplication();
 		Map<String, String> props = new HashMap<>();
 		props.put(AppDeployer.GROUP_PROPERTY_KEY, "foo");
 		props.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
+
 		AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, props);
 
 		log.info("Deploying {}...", request.getDefinition().getName());
@@ -249,12 +316,13 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 
 		Map<String, String> selector = Collections.singletonMap(SPRING_APP_KEY, deploymentId);
 		PodSpec spec = kubernetesClient.pods().withLabels(selector).list().getItems().get(0).getSpec();
+
 		Map<String, String> envVars = new HashMap<>();
 		for (EnvVar e : spec.getContainers().get(0).getEnv()) {
 			envVars.put(e.getName(), e.getValue());
 		}
 		assertThat(envVars.get("SPRING_CLOUD_APPLICATION_GROUP"), is("foo"));
-		assertThat(envVars.get("SPRING_APPLICATION_INDEX"), is("0"));
+		verifyAppEnv(deploymentId);
 
 		log.info("Undeploying {}...", deploymentId);
 		timeout = undeploymentTimeout();
@@ -271,7 +339,7 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 
 	@Override
 	protected Timeout deploymentTimeout() {
-		return new Timeout(60, 10000);
+		return new Timeout(60, 5000);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -2,11 +2,17 @@ package org.springframework.cloud.deployer.spi.kubernetes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.registerCustomDateFormat;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
 import org.junit.Test;
 import org.springframework.boot.bind.YamlConfigurationFactory;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
@@ -22,6 +28,7 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
  * Unit tests for {@link KubernetesAppDeployer}
  *
  * @author Donovan Muller
+ * @author David Turanski
  */
 public class KubernetesAppDeployerTests {
 
@@ -34,7 +41,7 @@ public class KubernetesAppDeployerTests {
 				new HashMap<>());
 
 		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec("1", appDeploymentRequest, 8080, 1, false);
+		PodSpec podSpec = deployer.createPodSpec("1", appDeploymentRequest, 8080, false);
 
 		assertThat(podSpec.getVolumes()).isEmpty();
 	}
@@ -51,7 +58,7 @@ public class KubernetesAppDeployerTests {
 		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
 
 		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec("1", appDeploymentRequest, 8080, 1, false);
+		PodSpec podSpec = deployer.createPodSpec("1", appDeploymentRequest, 8080,  false);
 
 		assertThat(podSpec.getVolumes()).containsOnly(
 				// volume 'testhostpath' defined in dataflow-server.yml should not be added
@@ -74,7 +81,7 @@ public class KubernetesAppDeployerTests {
 		appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
 
 		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
-		podSpec = deployer.createPodSpec("1", appDeploymentRequest, 8080, 1, false);
+		podSpec = deployer.createPodSpec("1", appDeploymentRequest, 8080,false);
 
 		assertThat(podSpec.getVolumes()).containsOnly(
 				new VolumeBuilder().withName("testhostpath").withNewHostPath("/test/override/hostPath").build(),
@@ -91,13 +98,62 @@ public class KubernetesAppDeployerTests {
 		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
 
 		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec("1", appDeploymentRequest, 8080, 1, false);
+		PodSpec podSpec = deployer.createPodSpec("1", appDeploymentRequest, 8080,false);
 
 		assertThat(podSpec.getNodeSelector()).containsOnly(
 				entry("disktype", "ssd"),
 				entry("os", "linux")
 		);
 
+	}
+
+	@Test
+	public void createStatufulSet() throws Exception {
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		Map<String, String> props = new HashMap<>();
+		props.put(KubernetesAppDeployer.COUNT_PROPERTY_KEY, "3");
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
+		String appId = deployer.createDeploymentId(appDeploymentRequest);
+		Map<String,String> idMap = deployer.createIdMap(appId,appDeploymentRequest);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		String statefulSetJson = deployer.createStatefulSet(appId, appDeploymentRequest, idMap, 8080);
+
+		Map<String, Object> statefulSetMap = objectMapper.readValue(statefulSetJson, HashMap.class);
+
+		Map<String, Object> specMap = (Map<String,Object>)statefulSetMap.get("spec");
+		assertThat(specMap.get("podManagementPolicy")).isEqualTo("Parallel");
+
+		StatefulSet statefulSet = objectMapper.readValue(statefulSetJson, StatefulSet.class);
+
+		assertThat(statefulSet.getSpec().getReplicas()).isEqualTo(3);
+		assertThat(statefulSet.getSpec().getServiceName()).isEqualTo(appId);
+		assertThat(statefulSet.getMetadata().getName()).isEqualTo(appId);
+
+		assertThat(statefulSet.getSpec().getSelector().getMatchLabels()).containsAllEntriesOf(deployer
+			.createIdMap(appId,appDeploymentRequest));
+		assertThat(statefulSet.getSpec().getSelector().getMatchLabels()).contains(
+			entry(KubernetesAppDeployer.SPRING_MARKER_KEY, KubernetesAppDeployer.SPRING_MARKER_VALUE));
+
+		assertThat(statefulSet.getSpec().getTemplate().getMetadata().getLabels()).containsAllEntriesOf(idMap);
+		assertThat(statefulSet.getSpec().getTemplate().getMetadata().getLabels()).contains(
+			entry(KubernetesAppDeployer.SPRING_MARKER_KEY, KubernetesAppDeployer.SPRING_MARKER_VALUE));
+
+		Container container = statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0);
+
+		assertThat(container.getName()).isEqualTo(appId);
+		assertThat(container.getPorts().get(0).getContainerPort()).isEqualTo(8080);
+		assertThat(container.getImage()).isEqualTo(getResource().getURI().getSchemeSpecificPart().toString());
+
+		PersistentVolumeClaim pvc = statefulSet.getSpec().getVolumeClaimTemplates().get(0);
+		assertThat(pvc.getMetadata().getName()).isEqualTo(appId);
+
+		assertThat(pvc.getSpec().getAccessModes()).containsOnly("ReadWriteOnce");
+		assertThat(pvc.getSpec().getResources().getLimits().get("storage").getAmount()).isEqualTo("0Mi");
+		assertThat(pvc.getSpec().getResources().getRequests().get("storage").getAmount()).isEqualTo("0Mi");
 	}
 
 	private Resource getResource() {


### PR DESCRIPTION
This PR resolves #150 and a couple of related items.

* Indexed applications are deployed as StatefulSets. K8s manages creates a separate pod for each replica and automatically indexes the pod's name and HOSTNAME natively. This makes it much easier to manage indexed apps, necessary for partitioning, and also to scale indexed apps.
* `KubernetesDeploymentProperties.setCreateDeployment(), isCreateDeployment()` and the associated `KubernetesAppDeployer.createReplicationController()` are deprecated. The feature is still in place for non-indexed apps. 

TLDR; It works, but required a lot of creativity. 

* Some caveats re StatefulSet support:
  - The `statefulSet:spec:podManagementPolicy` is required to be set to `Parallel` in order to pass one of the integration tests that deploys an indexed app with 3 replicas and one configured to crash. The expected behavior is that this will be reported as a partial deployment with instance statuses ['deployed',deployed','failed'].  This is not possible with the default `podManagementPolicy=OrderedReady` which starts pods in index order and will not start the next one until the previous one is ready. This test is part of the spec for the AppDeployer SPI.
  - The current fabric8 Java KubernetesClient does not support `podManagementPolicy`. In order to set this value, it is necessary to by pass the client API and execute raw REST requests via the clients, OKHttp client. This is true for both create and delete operations. These are the only ones required.
  - StatefulSets require a `Persistent Volume Claim` used to persist application state.  Since dataflow apps are stateless, we don't really care about persistence. We create a 0 Mi persistent store. 
  - The primary advantage of StatefulSets is that it allows K8s to manage the indexing of Pods. Spring Cloud Stream Binder requires the `INSTANCE_INDEX` property to be set for partitioning. K8s does not currently expose the index. It can be derived from parsing the `HOSTNAME`. This is done by launching an InitContainer that can execute a shell command to extract the index value and write it to `config/application.properties` on a shared volume, from where the boot application can get it. This works well, but the init container takes about 20-30 seconds to do this.
  - The fabric8 client also does not know about `InitContainer`, so a "legacy" annotation is used to set the init container configuration as a JSON string. 
  - In order to figure out why `testMultipleInstancesDeploymentAndPartialState` was failing, I need some more detailed logging about specific conditions used to determine the deployment state. So I refactored the code used to determine the state of apps in the Running phase accordingly. It should be easier to read as well.