### PR TITLE
Update default memory from 512 to 1024

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -141,7 +141,7 @@ public class KubernetesDeployerProperties {
 	 * @deprecated Use spring.cloud.deployer.kubernetes.limits.memory
 	 */
 	@Deprecated
-	private String memory = "512Mi";
+	private String memory = "1024Mi";
 
 	/**
 	 * CPU to allocate for a Pod.


### PR DESCRIPTION
I asked about the change to a deprecated property via slack; I haven't received any suggestions, so I'm submitting it as a proposal. 

We can discuss any concerns here. 

Resolves spring-cloud/spring-cloud-deployer-kubernetes#164.