### PR TITLE
Add support to provide fabric8 client properties

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesClientFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,6 @@ package org.springframework.cloud.deployer.spi.kubernetes;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureOrder;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.deployer.spi.app.AppDeployer;
-import org.springframework.cloud.deployer.spi.task.TaskLauncher;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.Ordered;
 
 /**
  * The class responsible for creating Kubernetes Client based on the deployer properties.

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -19,10 +19,11 @@ package org.springframework.cloud.deployer.spi.kubernetes;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.client.Config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * @author Florian Rosenberg
@@ -39,6 +40,16 @@ public class KubernetesDeployerProperties {
 	 * Constants for app deployment properties that don't have a deployer level default property.
 	 */
 	public static final String KUBERNETES_DEPLOYMENT_NODE_SELECTOR = "spring.cloud.deployer.kubernetes.deployment.nodeSelector";
+
+	private Config fabric8 = new Config();
+
+	public Config getFabric8() {
+		return this.fabric8;
+	}
+
+	public void setFabric8(Config fabric8) {
+		this.fabric8 = fabric8;
+	}
 
 	/**
 	 * Encapsulates resources for Kubernetes Container resource requests and limits

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -41,7 +41,7 @@ public class KubernetesDeployerProperties {
 	 */
 	public static final String KUBERNETES_DEPLOYMENT_NODE_SELECTOR = "spring.cloud.deployer.kubernetes.deployment.nodeSelector";
 
-	private Config fabric8 = new Config();
+	private Config fabric8 = Config.autoConfigure(null);
 
 	public Config getFabric8() {
 		return this.fabric8;

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -16,17 +16,12 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.springframework.cloud.deployer.spi.app.DeploymentState.deployed;
-import static org.springframework.cloud.deployer.spi.app.DeploymentState.failed;
-import static org.springframework.cloud.deployer.spi.app.DeploymentState.unknown;
-import static org.springframework.cloud.deployer.spi.kubernetes.AbstractKubernetesDeployer.SPRING_APP_KEY;
-import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HostPathVolumeSource;
@@ -43,6 +38,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.ClassRule;
 import org.junit.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
@@ -55,12 +51,17 @@ import org.springframework.cloud.deployer.spi.test.Timeout;
 import org.springframework.core.io.Resource;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.springframework.cloud.deployer.spi.app.DeploymentState.deployed;
+import static org.springframework.cloud.deployer.spi.app.DeploymentState.failed;
+import static org.springframework.cloud.deployer.spi.app.DeploymentState.unknown;
+import static org.springframework.cloud.deployer.spi.kubernetes.AbstractKubernetesDeployer.SPRING_APP_KEY;
+import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
 
 /**
  * Integration tests for {@link KubernetesAppDeployer}.

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesConfigurationPropertiesTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesConfigurationPropertiesTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {KubernetesAutoConfiguration.class}, properties = {
+		"spring.cloud.deployer.kubernetes.fabric8.trustCerts=true",
+		"spring.cloud.deployer.kubernetes.fabric8.masterUrl=http://localhost:8090",
+		"spring.cloud.deployer.kubernetes.namespace=testing"
+})
+public class KubernetesConfigurationPropertiesTests {
+
+	@Autowired
+	private KubernetesClient kubernetesClient;
+
+	@Test
+	public void testFabric8Properties() {
+		assertEquals("http://localhost:8090", kubernetesClient.getMasterUrl().toString());
+		assertEquals("testing", kubernetesClient.getNamespace());
+		assertEquals("http://localhost:8090", kubernetesClient.getConfiguration().getMasterUrl());
+		assertEquals(Boolean.TRUE, kubernetesClient.getConfiguration().isTrustCerts());
+	}
+}


### PR DESCRIPTION
 - Add fabric8 client config properties as part of the k8s deployer properties under the prefix `fabric8`
 - Merge `namespace` property from deployer properties if not set in client properties already
 - Use these properties when creating k8s fabric8 client
    - Add a factory class that instantiates the client after merging the namespace property from deployer properties
 - Add test to verify the changes

Resolves #206