### PR TITLE
Top-level property "namespace" is ignored when creating a new KubernetesClient

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesClientFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,17 +24,18 @@ import io.fabric8.kubernetes.client.KubernetesClient;
  * The class responsible for creating Kubernetes Client based on the deployer properties.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Chris Schaefer
  */
 public class KubernetesClientFactory {
 
 	public static KubernetesClient getKubernetesClient(KubernetesDeployerProperties kubernetesDeployerProperties) {
 		Config config = kubernetesDeployerProperties.getFabric8();
-		// Since namespace is used as a deployer as well as a client property, merging it from the deployer if it is not
-		// already set in the client properties.
-		if (config.getNamespace() == null) {
+
+		// use any fabric8 auto-detected properties, only set namespace from deployer properties if not null
+		if (kubernetesDeployerProperties.getNamespace() != null) {
 			config.setNamespace(kubernetesDeployerProperties.getNamespace());
 		}
+
 		return new DefaultKubernetesClient(config);
 	}
-
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -121,8 +121,7 @@ public class KubernetesDeployerProperties {
 		}
 	}
 
-	private static String KUBERNETES_NAMESPACE =
-			System.getenv("KUBERNETES_NAMESPACE") != null ? System.getenv("KUBERNETES_NAMESPACE") : "default";
+	private static String KUBERNETES_NAMESPACE = System.getenv("KUBERNETES_NAMESPACE");
 
 	/**
 	 * Namespace to use.

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -90,8 +90,9 @@ import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.even
  * @Author David Turanski
  * @author Chris Schaefer
  */
-@SpringBootTest(classes = { KubernetesAutoConfiguration.class }, properties = {
-		"logging.level.org.springframework.cloud.deployer.spi=INFO"
+@SpringBootTest(classes = {KubernetesAutoConfiguration.class}, properties = {
+		"logging.level.org.springframework.cloud.deployer.spi=INFO",
+		"spring.cloud.deployer.kubernetes.namespace=default"
 })
 public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIntegrationTests {
 

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherIntegrationTests.java
@@ -51,7 +51,9 @@ import org.springframework.core.io.Resource;
  * @author Thomas Risberg
  * @author Chris Schaefer
  */
-@SpringBootTest(classes = {KubernetesAutoConfiguration.class})
+@SpringBootTest(classes = {KubernetesAutoConfiguration.class}, properties = {
+		"spring.cloud.deployer.kubernetes.namespace=default"
+})
 public class KubernetesTaskLauncherIntegrationTests extends AbstractTaskLauncherIntegrationTests {
 
 	@ClassRule

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherWithJobIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherWithJobIntegrationTests.java
@@ -53,7 +53,8 @@ import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.even
  * @author Chris Schaefer
  */
 @SpringBootTest(classes = {KubernetesAutoConfiguration.class})
-@TestPropertySource(properties = {"spring.cloud.deployer.kubernetes.create-job=true"})
+@TestPropertySource(properties = {"spring.cloud.deployer.kubernetes.create-job=true",
+		"spring.cloud.deployer.kubernetes.namespace=default"})
 public class KubernetesTaskLauncherWithJobIntegrationTests extends AbstractTaskLauncherIntegrationTests {
 
 	@ClassRule

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTestSupport.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,13 +26,13 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
 /**
  * JUnit {@link org.junit.Rule} that detects the fact that a Kubernetes installation is available.
  *
  * @author Thomas Risberg
+ * @author Chris Schaefer
  */
 public class KubernetesTestSupport extends AbstractExternalResourceTestSupport<KubernetesClient> {
 
@@ -65,7 +65,7 @@ public class KubernetesTestSupport extends AbstractExternalResourceTestSupport<K
 
 		@Bean
 		public KubernetesClient kubernetesClient() {
-			return new DefaultKubernetesClient().inNamespace(properties.getNamespace());
+			return KubernetesClientFactory.getKubernetesClient(this.properties);
 		}
 	}
 }


### PR DESCRIPTION
Resolves #261