### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ImagePullPolicy.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ImagePullPolicy.java
@@ -21,7 +21,7 @@ import org.springframework.boot.bind.RelaxedNames;
 import java.util.EnumSet;
 
 /**
- * ImagePullPolicy for containers inside a Kubernetes Pod, cf. http://kubernetes.io/docs/user-guide/images/
+ * ImagePullPolicy for containers inside a Kubernetes Pod, cf. https://kubernetes.io/docs/user-guide/images/
  *
  * @author Moritz Schulze
  */

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -82,52 +82,52 @@ public class KubernetesDeployerProperties {
 	 * Delay in seconds when the Kubernetes liveness check of the app container
 	 * should start checking its health status.
 	 */
-	// See http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	// See https://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
 	private int livenessProbeDelay = 10;
 
 	/**
 	 * Period in seconds for performing the Kubernetes liveness check of the app container.
 	 */
-	// See http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	// See https://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
 	private int livenessProbePeriod = 60;
 
 	/**
 	 * Timeout in seconds for the Kubernetes liveness check of the app container.
 	 * If the health check takes longer than this value to return it is assumed as 'unavailable'.
 	 */
-	// see http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	// see https://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
 	private int livenessProbeTimeout = 2;
 
 	/**
 	 * Path that app container has to respond to for liveness check.
 	 */
-	// See http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	// See https://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
 	private String livenessProbePath = "/health";
 
 	/**
 	 * Delay in seconds when the readiness check of the app container
 	 * should start checking if the module is fully up and running.
 	 */
-	// see http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	// see https://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
 	private int readinessProbeDelay = 10;
 
 	/**
 	 * Period in seconds to perform the readiness check of the app container.
 	 */
-	// see http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	// see https://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
 	private int readinessProbePeriod = 10;
 
 	/**
 	 * Timeout in seconds that the app container has to respond to its
 	 * health status during the readiness check.
 	 */
-	// see http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	// see https://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
 	private int readinessProbeTimeout = 2;
 
 	/**
 	 * Path that app container has to respond to for readiness check.
 	 */
-	// See http://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
+	// See https://kubernetes.io/v1.0/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks}
 	private String readinessProbePath = "/info";
 
 	/**
@@ -200,7 +200,7 @@ public class KubernetesDeployerProperties {
 
 	/**
 	 * The volumes that a Kubernetes instance supports.
-	 * See http://kubernetes.io/docs/user-guide/volumes/#types-of-volumes
+	 * See https://kubernetes.io/docs/user-guide/volumes/#types-of-volumes
 	 * This can be specified as a deployer property or as an app deployment property.
 	 * Deployment properties will override deployer properties.
 	 */


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://kubernetes.io/v1.0/docs/user-guide/production-pods.html (301) with 8 occurrences migrated to:  
  https://kubernetes.io/v1.0/docs/user-guide/production-pods.html ([https](https://kubernetes.io/v1.0/docs/user-guide/production-pods.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://kubernetes.io/docs/user-guide/images/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/images/ ([https](https://kubernetes.io/docs/user-guide/images/) result 301).
* [ ] http://kubernetes.io/docs/user-guide/volumes/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/volumes/ ([https](https://kubernetes.io/docs/user-guide/volumes/) result 301).