### PR TITLE
Updating Kube Deployer to handle sidecars in pod

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -136,7 +136,7 @@ public class AbstractKubernetesDeployer {
 				}
 				//find the container with the correct env var
 				for(Container container : pod.getSpec().getContainers()) {
-					if(container.getEnv().stream().anyMatch(envVar -> "SPRING_CLOUD_APPLICATION_GROUP".equals(envVar.getName()))) {
+					if(container.getEnv().stream().anyMatch(envVar -> "SPRING_CLOUD_APPLICATION_GUID".equals(envVar.getName()))) {
 						//find container status for this container
 						Optional<ContainerStatus> containerStatusOptional =
 							pod.getStatus().getContainerStatuses()

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppInstanceStatus.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppInstanceStatus.java
@@ -60,6 +60,14 @@ public class KubernetesAppInstanceStatus implements AppInstanceStatus {
 		this.runningPhaseDeploymentStateResolver = new DefaultRunningPhaseDeploymentStateResolver(properties);
 	}
 
+	public KubernetesAppInstanceStatus(Pod pod, Service service, KubernetesDeployerProperties properties, ContainerStatus containerStatus) {
+		this.pod = pod;
+		this.service = service;
+		this.properties = properties;
+		this.containerStatus = containerStatus;
+		this.runningPhaseDeploymentStateResolver = new DefaultRunningPhaseDeploymentStateResolver(properties);
+	}
+
 	/**
 	 * Override the default {@link RunningPhaseDeploymentStateResolver} implementation.
 	 *


### PR DESCRIPTION
We are running Istio with Spring Cloud Data Flow and noticed that the status was always returning Undeployed. Looking through the code, it seems that the Kube Deployer did not allow more than 1 container in a pod. 

The following code works in SCDF to get the correct status of pods with side cars, but I do not know the ramifications of this in other projects. I could also use some help in figuring out how to test this to make sure I'm not breaking anything else. 

Thank you!