### PR TITLE
Add support for secretKeyRef

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -234,6 +234,36 @@ public class KubernetesDeployerProperties {
 		}
 	}
 
+	public static class SecretKeyRef {
+		private String envVarName;
+		private String secretName;
+		private String dataKey;
+
+		public void setEnvVarName(String envVarName) {
+			this.envVarName = envVarName;
+		}
+
+		public String getEnvVarName() {
+			return envVarName;
+		}
+
+		public void setSecretName(String secretName) {
+			this.secretName = secretName;
+		}
+
+		public String getSecretName() {
+			return secretName;
+		}
+
+		public void setDataKey(String dataKey) {
+			this.dataKey = dataKey;
+		}
+
+		public String getDataKey() {
+			return dataKey;
+		}
+	}
+
 	private static String KUBERNETES_NAMESPACE = System.getenv("KUBERNETES_NAMESPACE");
 
 	/**
@@ -327,6 +357,11 @@ public class KubernetesDeployerProperties {
 	 * Tolerations to allocate for a Pod.
 	 */
 	private List<Toleration> tolerations = new ArrayList<>();
+
+	/**
+	 * Secret key references to be added to the Pod environment.
+	 */
+	private List<SecretKeyRef> secretKeyRefs = new ArrayList<>();
 
 	/**
 	 * Resources to assign for VolumeClaimTemplates (identified by metadata name) inside StatefulSet.
@@ -541,6 +576,14 @@ public class KubernetesDeployerProperties {
 
 	public void setTolerations(List<Toleration> tolerations) {
 		this.tolerations = tolerations;
+	}
+
+	public List<SecretKeyRef> getSecretKeyRefs() {
+		return secretKeyRefs;
+	}
+
+	public void setSecretKeyRefs(List<SecretKeyRef> secretKeyRefs) {
+		this.secretKeyRefs = secretKeyRefs;
 	}
 
 	public String[] getEnvironmentVariables() {

--- a/src/test/resources/dataflow-server-secretKeyRef.yml
+++ b/src/test/resources/dataflow-server-secretKeyRef.yml
@@ -1,0 +1,5 @@
+# spring.cloud.deployer.kubernetes.secretKeyRefs:
+secretKeyRefs:
+  - envVarName: "SECRET_PASSWORD"
+    secretName: "mySecret"
+    dataKey: "myPassword"


### PR DESCRIPTION
Resolves #264

Some testing notes:

can be tested on minikube. build deployer + skipper + scdf + images / set imagePullPolicy on both servers to `Never` to use local build

create a secret ie: put the following into `secret.yaml`:
```
apiVersion: v1
kind: Secret
metadata:
  name: testsecret
type: Opaque
data:
  password: dGhlcGFzc3dvcmQ=
```

`$ kubectl create -f secret.yaml`

in dataflow shell:

`app import --uri https://dataflow.spring.io/rabbitmq-docker-latest`

* for per-application setting:

```
stream create --name ticktock --definition "time | log"
stream deploy --name ticktock --properties "deployer.log.kubernetes.secretKeyRefs=[{envVarName: 'MY_SECRET', secretName: 'testsecret', dataKey: 'password'}]"
```

* for global setting edit the appropriate config map, for example add the following to skipper-config-rabbit:

```
                accounts:
                  default:
                    ....
                    secretKeyRefs:
                      - envVarName: MY_SECRET
                        secretName: testsecret
                        dataKey: password
```

then do:

`stream create --name ticktock --definition "time | log" --deploy`

* then verify the appropriate pod envs -- the specific pod if per app deployment, either pod if global:

`$ kubectl exec -it ticktock-log-v1-949b9c498-s9zh8 -- printenv | grep MY_SECRET`

replacing `ticktock-log-v1-949b9c498-s9zh8` with your log pod name, should result in:

```$ kubectl exec -it ticktock-log-v1-949b9c498-s9zh8  -- printenv | grep MY_SECRET
MY_SECRET=thepassword
```

* delete the secret:

`kubectl delete secret/testsecret`