### PR TITLE
Support ConfigMapKeyRef

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -234,9 +234,8 @@ public class KubernetesDeployerProperties {
 		}
 	}
 
-	public static class SecretKeyRef {
+	static class KeyRef {
 		private String envVarName;
-		private String secretName;
 		private String dataKey;
 
 		public void setEnvVarName(String envVarName) {
@@ -247,6 +246,18 @@ public class KubernetesDeployerProperties {
 			return envVarName;
 		}
 
+		public void setDataKey(String dataKey) {
+			this.dataKey = dataKey;
+		}
+
+		public String getDataKey() {
+			return dataKey;
+		}
+	}
+
+	public static class SecretKeyRef extends KeyRef {
+		private String secretName;
+
 		public void setSecretName(String secretName) {
 			this.secretName = secretName;
 		}
@@ -254,13 +265,17 @@ public class KubernetesDeployerProperties {
 		public String getSecretName() {
 			return secretName;
 		}
+	}
 
-		public void setDataKey(String dataKey) {
-			this.dataKey = dataKey;
+	public static class ConfigMapKeyRef extends KeyRef {
+		private String configMapName;
+
+		public void setConfigMapName(String configMapName) {
+			this.configMapName = configMapName;
 		}
 
-		public String getDataKey() {
-			return dataKey;
+		public String getConfigMapName() {
+			return configMapName;
 		}
 	}
 
@@ -362,6 +377,11 @@ public class KubernetesDeployerProperties {
 	 * Secret key references to be added to the Pod environment.
 	 */
 	private List<SecretKeyRef> secretKeyRefs = new ArrayList<>();
+
+	/**
+	 * ConfigMap key references to be added to the Pod environment.
+	 */
+	private List<ConfigMapKeyRef> configMapKeyRefs = new ArrayList<>();
 
 	/**
 	 * Resources to assign for VolumeClaimTemplates (identified by metadata name) inside StatefulSet.
@@ -584,6 +604,14 @@ public class KubernetesDeployerProperties {
 
 	public void setSecretKeyRefs(List<SecretKeyRef> secretKeyRefs) {
 		this.secretKeyRefs = secretKeyRefs;
+	}
+
+	public List<ConfigMapKeyRef> getConfigMapKeyRefs() {
+		return configMapKeyRefs;
+	}
+
+	public void setConfigMapKeyRefs(List<ConfigMapKeyRef> configMapKeyRefs) {
+		this.configMapKeyRefs = configMapKeyRefs;
 	}
 
 	public String[] getEnvironmentVariables() {

--- a/src/test/resources/dataflow-server-configMapKeyRef.yml
+++ b/src/test/resources/dataflow-server-configMapKeyRef.yml
@@ -1,0 +1,5 @@
+# spring.cloud.deployer.kubernetes.configMapKeyRefs:
+configMapKeyRefs:
+  - envVarName: "MY_ENV"
+    configMapName: "myConfigMap"
+    dataKey: "envName"


### PR DESCRIPTION
Resolves #298


testing notes - pretty much same as secret key ref:

* build deployer, skipper, scdf

* create test CM, ie:

`kubectl create configmap testcm --from-literal=platform=k8s`

in dataflow shell:

`app import --uri https://dataflow.spring.io/rabbitmq-docker-latest`

* for per app deployment:

```
stream create --name ticktock --definition "time | log"
stream deploy --name ticktock --properties "deployer.log.kubernetes.configMapKeyRefs=[{envVarName: 'MY_CM', configMapName: 'testcm', dataKey: 'platform'}]"
```

* for global setting edit the appropriate config map, for example add the following to skipper-config-rabbit:

```
                accounts:
                  default:
                    ....
                    configMapKeyRefs:
                      - envVarName: MY_CM
                        configMapName: testcm
                        dataKey: platform
```

then deploy without props:

`stream create --name ticktock --definition "time | log" --deploy`

* in both cases:

then verify the appropriate pod envs -- the specific pod if per app deployment, either pod if global:

`$ kubectl exec -it ticktock-log-v1-949b9c498-s9zh8 -- printenv | grep MY_CM`

replacing `ticktock-log-v1-949b9c498-s9zh8` with your log pod name, should result in:

`MY_CM=k8s`

delete the CM:

`$ kubectl delete cm/testcm`
