### PR TITLE
Add ability to configure a basic pod security context

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -279,6 +279,27 @@ public class KubernetesDeployerProperties {
 		}
 	}
 
+	public static class PodSecurityContext {
+		private Long runAsUser;
+		private Long fsGroup;
+
+		public void setRunAsUser(Long runAsUser) {
+			this.runAsUser = runAsUser;
+		}
+
+		public Long getRunAsUser() {
+			return this.runAsUser;
+		}
+
+		public void setFsGroup(Long fsGroup) {
+			this.fsGroup = fsGroup;
+		}
+
+		public Long getFsGroup() {
+			return fsGroup;
+		}
+	}
+
 	private static String KUBERNETES_NAMESPACE = System.getenv("KUBERNETES_NAMESPACE");
 
 	/**
@@ -476,6 +497,11 @@ public class KubernetesDeployerProperties {
 	 * Service account name to use for app deployments
 	 */
 	private String deploymentServiceAccountName;
+
+	/**
+	 * The security context to apply to created pod's.
+	 */
+	private PodSecurityContext podSecurityContext;
 
 	public String getNamespace() {
 		return namespace;
@@ -764,5 +790,13 @@ public class KubernetesDeployerProperties {
 
 	public String getNodeSelector() {
 		return nodeSelector;
+	}
+
+	public void setPodSecurityContext(PodSecurityContext podSecurityContext) {
+		this.podSecurityContext = podSecurityContext;
+	}
+
+	public PodSecurityContext getPodSecurityContext() {
+		return podSecurityContext;
 	}
 }

--- a/src/test/resources/dataflow-server-podsecuritycontext.yml
+++ b/src/test/resources/dataflow-server-podsecuritycontext.yml
@@ -1,0 +1,4 @@
+# spring.cloud.deployer.kubernetes.podSecurityContext:
+podSecurityContext:
+  runAsUser: 65534
+  fsGroup: 65534


### PR DESCRIPTION
Resolves #306

some testing notes:

create for example a stream and set the `podSecurityContext` either per application or globally. the docs at: https://github.com/spring-cloud/spring-cloud-dataflow/pull/3354 show the variations.

to verify, the following can be done:

`kubectl get pod/ticktock-log-v1-6cfc4498f4-c5b8p -o yaml`

and look for the `securityContext` block, it should match the values set

or by inspecting the running process on the container (for long running ones like streams vs tasks), ie:

```
$ kubectl exec -it ticktock-log-v1-6cfc4498f4-c5b8p -- /bin/sh
$ ps -p 1 -o args,group,user
```

which would yield something like:

```
COMMAND                     GROUP    USER
java -jar /maven/log-sink-r nogroup  nobody
```

the UID/GID of 65534 resolves to `nobody` in this container.
