### PR TITLE
Refactor/cleanup scheduler SPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
 			<artifactId>kubernetes-client</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>${okhttp3.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.hashids</groupId>
 			<artifactId>hashids</artifactId>
 			<version>1.0.1</version>

--- a/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/ContainerCreator.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/ContainerCreator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.scheduler.spi.kubernetes;
+package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,8 +31,8 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.batch.CronJob;
 
-import org.springframework.cloud.deployer.scheduler.spi.core.ScheduleRequest;
 import org.springframework.cloud.deployer.spi.kubernetes.EntryPointStyle;
+import org.springframework.cloud.deployer.spi.scheduler.ScheduleRequest;
 import org.springframework.util.Assert;
 
 /**

--- a/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesScheduler.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesScheduler.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.scheduler.spi.kubernetes;
+package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,12 +33,12 @@ import io.fabric8.kubernetes.api.model.batch.CronJobList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 
-import org.springframework.cloud.deployer.scheduler.spi.core.CreateScheduleException;
-import org.springframework.cloud.deployer.scheduler.spi.core.ScheduleInfo;
-import org.springframework.cloud.deployer.scheduler.spi.core.ScheduleRequest;
-import org.springframework.cloud.deployer.scheduler.spi.core.Scheduler;
-import org.springframework.cloud.deployer.scheduler.spi.core.SchedulerException;
-import org.springframework.cloud.deployer.scheduler.spi.core.SchedulerPropertyKeys;
+import org.springframework.cloud.deployer.spi.scheduler.CreateScheduleException;
+import org.springframework.cloud.deployer.spi.scheduler.ScheduleInfo;
+import org.springframework.cloud.deployer.spi.scheduler.ScheduleRequest;
+import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
+import org.springframework.cloud.deployer.spi.scheduler.SchedulerException;
+import org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;

--- a/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerProperties.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.scheduler.spi.kubernetes;
+package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.deployer.spi.kubernetes.EntryPointStyle;

--- a/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerPropertyResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerPropertyResolver.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.scheduler.spi.kubernetes;
+package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -22,9 +22,9 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.springframework.cloud.deployer.scheduler.spi.core.ScheduleRequest;
 import org.springframework.cloud.deployer.spi.kubernetes.EntryPointStyle;
 import org.springframework.cloud.deployer.spi.kubernetes.ImagePullPolicy;
+import org.springframework.cloud.deployer.spi.scheduler.ScheduleRequest;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/RestartPolicy.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/RestartPolicy.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.scheduler.spi.kubernetes;
+package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
 
 /**
  * Defines restart policies that are available.

--- a/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/ContainerCreatorTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/ContainerCreatorTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.scheduler.spi.kubernetes;
+package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -32,9 +32,9 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import org.junit.Test;
 
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
-import org.springframework.cloud.deployer.scheduler.spi.core.ScheduleRequest;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.kubernetes.EntryPointStyle;
+import org.springframework.cloud.deployer.spi.scheduler.ScheduleRequest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.springframework.cloud.deployer.scheduler.spi.core.SchedulerPropertyKeys.CRON_EXPRESSION;
+import static org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys.CRON_EXPRESSION;
 
 
 /**
@@ -195,7 +195,7 @@ public class ContainerCreatorTests {
 	}
 
 	private Resource testApplication() {
-		return new DockerResource("springcloud/spring-cloud-scheduler-spi-test-app:latest");
+		return new DockerResource("springcloud/spring-cloud-deployer-spi-scheduler-test-app:latest");
 	}
 
 	private String randomName() {

--- a/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerPropertiesTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerPropertiesTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.scheduler.spi.kubernetes;
+package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
 
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;

--- a/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerTests.java
@@ -79,8 +79,8 @@ import static org.springframework.cloud.deployer.spi.scheduler.SchedulerProperty
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = NONE)
-@ContextConfiguration(classes = { KubernetesSchedulerTestsScheduler.Config.class })
-public class KubernetesSchedulerTestsScheduler extends AbstractSchedulerIntegrationTests {
+@ContextConfiguration(classes = { KubernetesSchedulerTests.Config.class })
+public class KubernetesSchedulerTests extends AbstractSchedulerIntegrationTests {
 	@ClassRule
 	public static KubernetesTestSupport kubernetesTestSupport = new KubernetesTestSupport();
 
@@ -138,7 +138,7 @@ public class KubernetesSchedulerTestsScheduler extends AbstractSchedulerIntegrat
 		return new DockerResource("springcloud/spring-cloud-deployer-spi-scheduler-test-app:latest");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = CreateScheduleException.class)
 	public void testMissingSchedule() {
 		AppDefinition appDefinition = new AppDefinition(randomName(), null);
 		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, null, null, null, null, testApplication());

--- a/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerTestsScheduler.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerTestsScheduler.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.scheduler.spi.kubernetes;
+package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,15 +48,15 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.KubernetesTestSupport;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
-import org.springframework.cloud.deployer.scheduler.spi.core.CreateScheduleException;
-import org.springframework.cloud.deployer.scheduler.spi.core.ScheduleInfo;
-import org.springframework.cloud.deployer.scheduler.spi.core.ScheduleRequest;
-import org.springframework.cloud.deployer.scheduler.spi.core.Scheduler;
-import org.springframework.cloud.deployer.scheduler.spi.core.SchedulerPropertyKeys;
-import org.springframework.cloud.deployer.scheduler.spi.test.AbstractSchedulerIntegrationTests;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.kubernetes.EntryPointStyle;
 import org.springframework.cloud.deployer.spi.kubernetes.ImagePullPolicy;
+import org.springframework.cloud.deployer.spi.scheduler.CreateScheduleException;
+import org.springframework.cloud.deployer.spi.scheduler.ScheduleInfo;
+import org.springframework.cloud.deployer.spi.scheduler.ScheduleRequest;
+import org.springframework.cloud.deployer.spi.scheduler.Scheduler;
+import org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys;
+import org.springframework.cloud.deployer.spi.scheduler.test.AbstractSchedulerIntegrationTests;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
@@ -70,7 +70,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
-import static org.springframework.cloud.deployer.scheduler.spi.core.SchedulerPropertyKeys.CRON_EXPRESSION;
+import static org.springframework.cloud.deployer.spi.scheduler.SchedulerPropertyKeys.CRON_EXPRESSION;
 
 /**
  * Tests for Kubernetes {@link Scheduler} implementation.
@@ -135,7 +135,7 @@ public class KubernetesSchedulerTestsScheduler extends AbstractSchedulerIntegrat
 	}
 
 	protected Resource testApplication() {
-		return new DockerResource("springcloud/spring-cloud-scheduler-spi-test-app:latest");
+		return new DockerResource("springcloud/spring-cloud-deployer-spi-scheduler-test-app:latest");
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
 - Move scheduler packages into `org.springframework.cloud.deployer.spi.scheduler`
 - Remove RelaxedNames

Resolves #319