### PR TITLE
Add basic support for custom init containers

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -224,6 +225,8 @@ public class AbstractKubernetesDeployer {
 		setPodSecurityContext(request, podSpec);
 
 		setAffinityRules(request, podSpec);
+
+		setInitContainer(request, podSpec);
 
 		return podSpec.build();
 	}
@@ -562,6 +565,23 @@ public class AbstractKubernetesDeployer {
 				|| affinity.getPodAffinity() != null
 				|| affinity.getPodAntiAffinity() != null) {
 			podSpecBuilder.withAffinity(affinity);
+		}
+	}
+
+	private void setInitContainer(AppDeploymentRequest request, PodSpecBuilder podSpec) {
+		KubernetesDeployerProperties deployerProperties = PropertyParserUtils.bindProperties(request,
+				"spring.cloud.deployer.kubernetes.initContainer", "initContainer");
+
+		KubernetesDeployerProperties.InitContainer initContainer = deployerProperties.getInitContainer();
+
+		if (initContainer != null) {
+			Container container = new ContainerBuilder()
+					.withName(initContainer.getContainerName())
+					.withImage(initContainer.getImageName())
+					.withCommand(initContainer.getCommands())
+					.build();
+
+			podSpec.addToInitContainers(container);
 		}
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -304,6 +304,36 @@ public class KubernetesDeployerProperties {
 		}
 	}
 
+	public static class InitContainer {
+		private String imageName;
+		private String containerName;
+		private List<String> commands;
+
+		public String getImageName() {
+			return imageName;
+		}
+
+		public void setImageName(String imageName) {
+			this.imageName = imageName;
+		}
+
+		public String getContainerName() {
+			return containerName;
+		}
+
+		public void setContainerName(String containerName) {
+			this.containerName = containerName;
+		}
+
+		public List<String> getCommands() {
+			return commands;
+		}
+
+		public void setCommands(List<String> commands) {
+			this.commands = commands;
+		}
+	}
+
 	private static String KUBERNETES_NAMESPACE = System.getenv("KUBERNETES_NAMESPACE");
 
 	/**
@@ -526,6 +556,11 @@ public class KubernetesDeployerProperties {
 	 * A custom init container image name to use when creating a StatefulSet
 	 */
 	private String statefulSetInitContainerImageName;
+
+	/**
+	 * A custom init container to apply.
+	 */
+	private InitContainer initContainer;
 
 	public String getNamespace() {
 		return namespace;
@@ -854,5 +889,13 @@ public class KubernetesDeployerProperties {
 
 	public void setStatefulSetInitContainerImageName(String statefulSetInitContainerImageName) {
 		this.statefulSetInitContainerImageName = statefulSetInitContainerImageName;
+	}
+
+	public InitContainer getInitContainer() {
+		return initContainer;
+	}
+
+	public void setInitContainer(InitContainer initContainer) {
+		this.initContainer = initContainer;
 	}
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -1002,6 +1003,50 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 		assertTrue(servicePorts.stream().anyMatch(o -> o.getName().equals("port-8080")));
 		assertTrue(servicePorts.stream().anyMatch(o -> o.getPort().equals(9090)));
 		assertTrue(servicePorts.stream().anyMatch(o -> o.getName().equals("port-9090")));
+
+		log.info("Undeploying {}...", deploymentId);
+		timeout = undeploymentTimeout();
+		kubernetesAppDeployer.undeploy(deploymentId);
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.hasProperty("state", is(unknown))), timeout.maxAttempts, timeout.pause));
+	}
+
+	@Test
+	public void testCreateInitContainer() {
+		log.info("Testing {}...", "CreateInitContainer");
+		KubernetesAppDeployer kubernetesAppDeployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(),
+				kubernetesClient);
+
+		Map<String, String> props = Collections.singletonMap("spring.cloud.deployer.kubernetes.initContainer",
+				"{containerName: 'test', imageName: 'busybox:latest', commands: ['sh', '-c', 'echo hello']}");
+
+		AppDefinition definition = new AppDefinition(randomName(), null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, testApplication(), props);
+
+		log.info("Deploying {}...", request.getDefinition().getName());
+		String deploymentId = kubernetesAppDeployer.deploy(request);
+		Timeout timeout = deploymentTimeout();
+		assertThat(deploymentId, eventually(hasStatusThat(
+				Matchers.hasProperty("state", is(deployed))), timeout.maxAttempts, timeout.pause));
+
+		Deployment deployment = kubernetesClient.apps().deployments().withName(request.getDefinition().getName()).get();
+		List<Container> initContainers = deployment.getSpec().getTemplate().getSpec().getInitContainers();
+
+		Optional<Container> initContainer = initContainers.stream().filter(i -> i.getName().equals("test")).findFirst();
+		assertTrue("Init container not found", initContainer.isPresent());
+
+		Container testInitContainer = initContainer.get();
+
+		assertEquals("Unexpected init container name", testInitContainer.getName(), "test");
+		assertEquals("Unexpected init container image", testInitContainer.getImage(), "busybox:latest");
+
+		List<String> commands = testInitContainer.getCommand();
+
+		assertTrue("Init container commands missing", commands != null && !commands.isEmpty());
+		assertTrue("Invalid number of init container commands", commands.size() == 3);
+		assertEquals("sh", commands.get(0));
+		assertEquals("-c", commands.get(1));
+		assertEquals("echo hello", commands.get(2));
 
 		log.info("Undeploying {}...", deploymentId);
 		timeout = undeploymentTimeout();


### PR DESCRIPTION
Resolves #187

---

some manual testing notes that can be done on minikube:

* build & install deployer
* build skipper & image locally
* build scdf & image locally
* change `ImagePullPolicy` in both scdf & skipper deployment to `Never`
* in scdf shell:

```
stream create --name ticktock --definition "time | log"
stream deploy --name ticktock --properties "deployer.log.kubernetes.initContainer={containerName: 'test', imageName: 'busybox:latest', commands: ['sh', '-c', 'echo hello']}"
```

* verify init container is present in pod:
`$ kubectl describe log-pod-name`

* verify under `Init Containers` there is a container called `test`
* there should be no errors, state `Terminated`, exit code 0

* verify command was executed:
```
$ kubectl logs log-pod-name -c test
hello
$
```
