### PR TITLE
Fix K8s deployer properties retrieval

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -258,8 +258,8 @@ public class DefaultContainerFactory implements ContainerFactory {
 	protected List<VolumeMount> getVolumeMounts(AppDeploymentRequest request) {
 		List<VolumeMount> volumeMounts = new ArrayList<>();
 
-		String volumeMountDeploymentProperty = request.getDeploymentProperties()
-			.getOrDefault("spring.cloud.deployer.kubernetes.volumeMounts", "");
+		String volumeMountDeploymentProperty = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+			"spring.cloud.deployer.kubernetes.volumeMounts");
 		if (!StringUtils.isEmpty(volumeMountDeploymentProperty)) {
 			try {
 				YamlPropertiesFactoryBean properties = new YamlPropertiesFactoryBean();
@@ -292,8 +292,8 @@ public class DefaultContainerFactory implements ContainerFactory {
 	 * @return a list of strings that represents the command and any arguments for that command
 	 */
 	private List<String> getContainerCommand(AppDeploymentRequest request) {
-		String containerCommand = request.getDeploymentProperties()
-			.getOrDefault("spring.cloud.deployer.kubernetes.containerCommand", "");
+		String containerCommand = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+			"spring.cloud.deployer.kubernetes.containerCommand", "");
 		return new CommandLineTokenizer(containerCommand).getArgs();
 	}
 
@@ -303,8 +303,8 @@ public class DefaultContainerFactory implements ContainerFactory {
 	 */
 	private List<Integer> getContainerPorts(AppDeploymentRequest request) {
 		List<Integer> containerPortList = new ArrayList<>();
-		String containerPorts = request.getDeploymentProperties()
-			.get("spring.cloud.deployer.kubernetes.containerPorts");
+		String containerPorts = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+			"spring.cloud.deployer.kubernetes.containerPorts", null);
 		if (containerPorts != null) {
 			String[] containerPortSplit = containerPorts.split(",");
 			for (String containerPort : containerPortSplit) {
@@ -323,8 +323,8 @@ public class DefaultContainerFactory implements ContainerFactory {
 	 */
 	private Map<String, String> getAppEnvironmentVariables(AppDeploymentRequest request) {
 		Map<String, String> appEnvVarMap = new HashMap<>();
-		String appEnvVar = request.getDeploymentProperties()
-			.get("spring.cloud.deployer.kubernetes.environmentVariables");
+		String appEnvVar = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+			"spring.cloud.deployer.kubernetes.environmentVariables", null);
 		if (appEnvVar != null) {
 			String[] appEnvVars = nestedCommaDelimitedVariableParser.parse(appEnvVar);
 			for (String envVar : appEnvVars) {
@@ -357,11 +357,11 @@ public class DefaultContainerFactory implements ContainerFactory {
 	private EntryPointStyle determineEntryPointStyle(KubernetesDeployerProperties properties,
 		AppDeploymentRequest request) {
 		EntryPointStyle entryPointStyle = null;
-		String deployProperty = request.getDeploymentProperties()
-			.get("spring.cloud.deployer.kubernetes.entryPointStyle");
-		if (deployProperty != null) {
+		String deployerPropertyValue = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+			"spring.cloud.deployer.kubernetes.entryPointStyle", null);
+		if (deployerPropertyValue != null) {
 			try {
-				entryPointStyle = EntryPointStyle.valueOf(deployProperty.toLowerCase());
+				entryPointStyle = EntryPointStyle.valueOf(deployerPropertyValue.toLowerCase());
 			}
 			catch (IllegalArgumentException ignore) {
 			}

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployer.java
@@ -351,12 +351,12 @@ public class KubernetesAppDeployer extends AbstractKubernetesDeployer implements
 		int externalPort) {
 		ServiceSpecBuilder spec = new ServiceSpecBuilder();
 		boolean isCreateLoadBalancer = false;
-		String createLoadBalancer = request.getDeploymentProperties()
-			.get("spring.cloud.deployer.kubernetes.createLoadBalancer");
-		String createNodePort = request.getDeploymentProperties()
-			.get("spring.cloud.deployer.kubernetes.createNodePort");
-		String additionalServicePorts = request.getDeploymentProperties()
-				.get("spring.cloud.deployer.kubernetes.servicePorts");
+		String createLoadBalancer = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+			"spring.cloud.deployer.kubernetes.createLoadBalancer");
+		String createNodePort = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+			"spring.cloud.deployer.kubernetes.createNodePort");
+		String additionalServicePorts = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+				"spring.cloud.deployer.kubernetes.servicePorts");
 
 		if (createLoadBalancer != null && createNodePort != null) {
 			throw new IllegalArgumentException("Cannot create NodePort and LoadBalancer at the same time.");
@@ -426,19 +426,17 @@ public class KubernetesAppDeployer extends AbstractKubernetesDeployer implements
 	}
 
 	private Map<String, String> getPodAnnotations(AppDeploymentRequest request) {
-		String annotationsProperty = request.getDeploymentProperties()
-				.getOrDefault("spring.cloud.deployer.kubernetes.podAnnotations", "");
-
-		if (StringUtils.isEmpty(annotationsProperty)) {
-			annotationsProperty = properties.getPodAnnotations();
+		String annotationsValue = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+				"spring.cloud.deployer.kubernetes.podAnnotations", "");
+		if (StringUtils.isEmpty(annotationsValue)) {
+			annotationsValue = properties.getPodAnnotations();
 		}
-
-		return PropertyParserUtils.getAnnotations(annotationsProperty);
+		return PropertyParserUtils.getAnnotations(annotationsValue);
 	}
 
 	private Map<String, String> getServiceAnnotations(AppDeploymentRequest request) {
-		String annotationsProperty = request.getDeploymentProperties()
-				.getOrDefault("spring.cloud.deployer.kubernetes.serviceAnnotations", "");
+		String annotationsProperty = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+				"spring.cloud.deployer.kubernetes.serviceAnnotations", "");
 
 		if (StringUtils.isEmpty(annotationsProperty)) {
 			annotationsProperty = properties.getServiceAnnotations();
@@ -450,8 +448,8 @@ public class KubernetesAppDeployer extends AbstractKubernetesDeployer implements
 	protected Map<String, String> getDeploymentLabels(AppDeploymentRequest request) {
 		Map<String, String> labels = new HashMap<>();
 
-		String deploymentLabels = request.getDeploymentProperties()
-				.getOrDefault("spring.cloud.deployer.kubernetes.deploymentLabels", "");
+		String deploymentLabels = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+				"spring.cloud.deployer.kubernetes.deploymentLabels", "");
 
 		if (StringUtils.hasText(deploymentLabels)) {
 			String[] deploymentLabel = deploymentLabels.split(",");
@@ -576,8 +574,8 @@ public class KubernetesAppDeployer extends AbstractKubernetesDeployer implements
 
 	private String getStatefulSetInitContainerImageName(AppDeploymentRequest request, KubernetesDeployerProperties
 														  kubernetesDeployerProperties) {
-		String statefulSetInitContainerImageName = request.getDeploymentProperties()
-				.getOrDefault("spring.cloud.deployer.kubernetes.statefulSetInitContainerImageName", "");
+		String statefulSetInitContainerImageName = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+				"spring.cloud.deployer.kubernetes.statefulSetInitContainerImageName", "");
 
 		if (StringUtils.hasText(statefulSetInitContainerImageName)) {
 			return statefulSetInitContainerImageName;

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -292,8 +292,8 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 	}
 
 	private Map<String, String> getJobAnnotations(AppDeploymentRequest request) {
-		String annotationsProperty = request.getDeploymentProperties()
-				.getOrDefault("spring.cloud.deployer.kubernetes.jobAnnotations", "");
+		String annotationsProperty = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+				"spring.cloud.deployer.kubernetes.jobAnnotations", "");
 
 		if (StringUtils.isEmpty(annotationsProperty)) {
 			annotationsProperty = properties.getJobAnnotations();

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/LivenessProbeCreator.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/LivenessProbeCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Creates a Liveness Probe.
  *
  * @author Chris Schaefer
+ * @author Ilayaperumal Gopinathan
  */
 class LivenessProbeCreator extends ProbeCreator {
 	private static final String PROBE_PROPERTY_PREFIX = KUBERNETES_DEPLOYER_PREFIX + ".liveness";
@@ -32,9 +35,10 @@ class LivenessProbeCreator extends ProbeCreator {
 	@Override
 	public Integer getPort() {
 		String probePortKey = PROBE_PROPERTY_PREFIX + "ProbePort";
+		String probePortValue = getDeploymentPropertyValue(probePortKey);
 
-		if (getDeploymentProperties().containsKey(probePortKey)) {
-			return Integer.parseInt(getDeploymentProperties().get(probePortKey));
+		if (StringUtils.hasText(probePortValue)) {
+			return Integer.parseInt(probePortValue);
 		}
 
 		if (getKubernetesDeployerProperties().getLivenessProbePort() != null) {
@@ -51,9 +55,10 @@ class LivenessProbeCreator extends ProbeCreator {
 	@Override
 	protected String getProbePath() {
 		String probePathKey = PROBE_PROPERTY_PREFIX + "ProbePath";
+		String probePathValue =  getDeploymentPropertyValue(probePathKey);
 
-		if (getDeploymentProperties().containsKey(probePathKey)) {
-			return getDeploymentProperties().get(probePathKey);
+		if (StringUtils.hasText(probePathValue)) {
+			return probePathValue;
 		}
 
 		if (getKubernetesDeployerProperties().getLivenessProbePath() != null) {
@@ -70,9 +75,10 @@ class LivenessProbeCreator extends ProbeCreator {
 	@Override
 	protected int getTimeout() {
 		String probeTimeoutKey = PROBE_PROPERTY_PREFIX + "ProbeTimeout";
+		String probeTimeoutValue = getDeploymentPropertyValue(probeTimeoutKey);
 
-		if (getDeploymentProperties().containsKey(probeTimeoutKey)) {
-			return Integer.valueOf(getDeploymentProperties().get(probeTimeoutKey));
+		if (StringUtils.hasText(probeTimeoutValue)) {
+			return Integer.valueOf(probeTimeoutValue);
 		}
 
 		return getKubernetesDeployerProperties().getLivenessProbeTimeout();
@@ -81,9 +87,10 @@ class LivenessProbeCreator extends ProbeCreator {
 	@Override
 	protected int getInitialDelay() {
 		String probeDelayKey = PROBE_PROPERTY_PREFIX + "ProbeDelay";
+		String probeDelayValue = getDeploymentPropertyValue(probeDelayKey);
 
-		if (getDeploymentProperties().containsKey(probeDelayKey)) {
-			return Integer.valueOf(getDeploymentProperties().get(probeDelayKey));
+		if (StringUtils.hasText(probeDelayValue)) {
+			return Integer.valueOf(probeDelayValue);
 		}
 
 		return getKubernetesDeployerProperties().getLivenessProbeDelay();
@@ -92,9 +99,10 @@ class LivenessProbeCreator extends ProbeCreator {
 	@Override
 	protected int getPeriod() {
 		String probePeriodKey = PROBE_PROPERTY_PREFIX + "ProbePeriod";
+		String probePeriodValue = getDeploymentPropertyValue(probePeriodKey);
 
-		if (getDeploymentProperties().containsKey(probePeriodKey)) {
-			return Integer.valueOf(getDeploymentProperties().get(probePeriodKey));
+		if (StringUtils.hasText(probePeriodValue)) {
+			return Integer.valueOf(probePeriodValue);
 		}
 
 		return getKubernetesDeployerProperties().getLivenessProbePeriod();

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ProbeCreator.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ProbeCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ import java.util.Map;
  * Base class for creating Probe's
  *
  * @author Chris Schaefer
+ * @author Ilayaperumal Gopinathan
  */
 abstract class ProbeCreator {
 	protected static final String KUBERNETES_DEPLOYER_PREFIX = "spring.cloud.deployer.kubernetes";
@@ -89,15 +91,21 @@ abstract class ProbeCreator {
 		return containerConfiguration.getAppDeploymentRequest().getDeploymentProperties();
 	}
 
+	protected String getDeploymentPropertyValue(String propertyName) {
+		return PropertyParserUtils.getDeploymentPropertyValue(this.containerConfiguration.getAppDeploymentRequest().getDeploymentProperties(),
+				propertyName, null);
+	}
+
 	protected Integer getDefaultPort() {
 		return containerConfiguration.getExternalPort();
 	}
 
 	protected boolean useBoot1ProbePath() {
 		String bootMajorVersionProperty = KUBERNETES_DEPLOYER_PREFIX + ".bootMajorVersion";
+		String bootMajorVersionValue = getDeploymentPropertyValue(bootMajorVersionProperty);
 
-		if (getDeploymentProperties().containsKey(bootMajorVersionProperty)) {
-			Integer bootMajorVersion = Integer.valueOf(getDeploymentProperties().get(bootMajorVersionProperty));
+		if (StringUtils.hasText(bootMajorVersionValue)) {
+			Integer bootMajorVersion = Integer.valueOf(bootMajorVersionValue);
 
 			if (bootMajorVersion == BOOT_1_MAJOR_VERSION) {
 				return true;

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ReadinessProbeCreator.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ReadinessProbeCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Creates a Readiness Probe.
  *
  * @author Chris Schaefer
+ * @author Ilayaperumal Gopinathan
  */
 class ReadinessProbeCreator extends ProbeCreator {
 	private static final String PROBE_PROPERTY_PREFIX = KUBERNETES_DEPLOYER_PREFIX + ".readiness";
@@ -32,9 +35,10 @@ class ReadinessProbeCreator extends ProbeCreator {
 	@Override
 	public Integer getPort() {
 		String probePortKey = PROBE_PROPERTY_PREFIX + "ProbePort";
+		String probePortValue = getDeploymentPropertyValue(probePortKey);
 
-		if (getDeploymentProperties().containsKey(probePortKey)) {
-			return Integer.parseInt(getDeploymentProperties().get(probePortKey));
+		if (StringUtils.hasText(probePortValue)) {
+			return Integer.parseInt(probePortValue);
 		}
 
 		if (getKubernetesDeployerProperties().getReadinessProbePort() != null) {
@@ -51,9 +55,10 @@ class ReadinessProbeCreator extends ProbeCreator {
 	@Override
 	protected String getProbePath() {
 		String probePathKey = PROBE_PROPERTY_PREFIX + "ProbePath";
+		String probePathValue = getDeploymentPropertyValue(probePathKey);
 
-		if (getDeploymentProperties().containsKey(probePathKey)) {
-			return getDeploymentProperties().get(probePathKey);
+		if (StringUtils.hasText(probePathValue)) {
+			return probePathValue;
 		}
 
 		if (getKubernetesDeployerProperties().getReadinessProbePath() != null) {
@@ -70,9 +75,10 @@ class ReadinessProbeCreator extends ProbeCreator {
 	@Override
 	protected int getTimeout() {
 		String probeTimeoutKey = PROBE_PROPERTY_PREFIX + "ProbeTimeout";
+		String probeTimeoutValue = getDeploymentPropertyValue(probeTimeoutKey);
 
-		if (getDeploymentProperties().containsKey(probeTimeoutKey)) {
-			return Integer.valueOf(getDeploymentProperties().get(probeTimeoutKey));
+		if (StringUtils.hasText(probeTimeoutValue)) {
+			return Integer.valueOf(probeTimeoutValue);
 		}
 
 		return getKubernetesDeployerProperties().getReadinessProbeTimeout();
@@ -81,9 +87,10 @@ class ReadinessProbeCreator extends ProbeCreator {
 	@Override
 	protected int getInitialDelay() {
 		String probeDelayKey = PROBE_PROPERTY_PREFIX + "ProbeDelay";
+		String probeDelayValue = getDeploymentPropertyValue(probeDelayKey);
 
-		if (getDeploymentProperties().containsKey(probeDelayKey)) {
-			return Integer.valueOf(getDeploymentProperties().get(probeDelayKey));
+		if (StringUtils.hasText(probeDelayValue)) {
+			return Integer.valueOf(probeDelayValue);
 		}
 
 		return getKubernetesDeployerProperties().getReadinessProbeDelay();
@@ -92,9 +99,10 @@ class ReadinessProbeCreator extends ProbeCreator {
 	@Override
 	protected int getPeriod() {
 		String probePeriodKey = PROBE_PROPERTY_PREFIX + "ProbePeriod";
+		String probePeriodValue = getDeploymentPropertyValue(probePeriodKey);
 
-		if (getDeploymentProperties().containsKey(probePeriodKey)) {
-			return Integer.valueOf(getDeploymentProperties().get(probePeriodKey));
+		if (StringUtils.hasText(probePeriodValue)) {
+			return Integer.valueOf(probePeriodValue);
 		}
 
 		return getKubernetesDeployerProperties().getReadinessProbePeriod();

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/support/RelaxedNames.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/support/RelaxedNames.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.scheduler.spi.kubernetes.support;
+package org.springframework.cloud.deployer.spi.kubernetes.support;
 
 import java.util.Iterator;
 import java.util.LinkedHashSet;

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
@@ -71,7 +71,7 @@ public class DefaultContainerFactoryTests {
 		Resource resource = getResource();
 		Map<String, String> props = new HashMap<>();
 		props.put("spring.cloud.deployer.kubernetes.limits.memory", "128Mi");
-		props.put("spring.cloud.deployer.kubernetes.environmentVariables",
+		props.put("spring.cloud.deployer.kubernetes.environment-variables",
 				"JAVA_OPTIONS=-Xmx64m,KUBERNETES_NAMESPACE=test-space");
 		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition,
 				resource, props);
@@ -323,7 +323,7 @@ public class DefaultContainerFactoryTests {
 		AppDefinition definition = new AppDefinition("app-test", null);
 		Resource resource = getResource();
 		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.livenessProbePort", Integer.toString(livenessPort));
+		props.put("spring.cloud.deployer.kubernetes.liveness-probe-port", Integer.toString(livenessPort));
 		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition,
 				resource, props);
 
@@ -473,7 +473,7 @@ public class DefaultContainerFactoryTests {
 				kubernetesDeployerProperties);
 
 		Map<String,String> appProperties = new HashMap<>();
-		appProperties.put("spring.cloud.deployer.kubernetes.bootMajorVersion", "1");
+		appProperties.put("spring.cloud.deployer.kubernetes.boot-major-version", "1");
 
 		AppDefinition definition = new AppDefinition("app-test", appProperties);
 		Resource resource = getResource();

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/PropertyParserUtilsTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/PropertyParserUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.cloud.deployer.spi.kubernetes;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -27,8 +28,10 @@ import org.junit.Test;
  * Tests for PropertyParserUtils
  *
  * @author Chris Schaefer
+ * @author Ilayaperumal Gopinathan
  */
 public class PropertyParserUtilsTests {
+
 	@Test
 	public void testAnnotationParseSingle() {
 		Map<String, String> annotations = PropertyParserUtils.getAnnotations("annotation:value");
@@ -67,5 +70,21 @@ public class PropertyParserUtilsTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void testAnnotationParseInvalidValue() {
 		PropertyParserUtils.getAnnotations("annotation1:value1,annotation2,annotation3:value3");
+	}
+
+	@Test
+	public void testDeploymentPropertyParsing() {
+		Map<String, String> deploymentProps = new HashMap<>();
+		deploymentProps.put("SPRING_CLOUD_DEPLOYER_KUBERNETES_IMAGEPULLPOLICY", "Never");
+		deploymentProps.put("spring.cloud.deployer.kubernetes.pod-annotations", "key1:value1,key2:value2");
+		deploymentProps.put("spring.cloud.deployer.kubernetes.serviceAnnotations", "key3:value3,key4:value4");
+		deploymentProps.put("spring.cloud.deployer.kubernetes.init-container.image-name", "springcloud/openjdk");
+		deploymentProps.put("spring.cloud.deployer.kubernetes.initContainer.containerName", "test");
+		deploymentProps.put("spring.cloud.deployer.kubernetes.init-container.commands", "['sh','echo hello']");
+		assertTrue(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.podAnnotations").equals("key1:value1,key2:value2"));
+		assertTrue(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.serviceAnnotations").equals("key3:value3,key4:value4"));
+		assertTrue(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.initContainer.imageName").equals("springcloud/openjdk"));
+		assertTrue(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.initContainer.imageName").equals("springcloud/openjdk"));
+		assertTrue(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.imagePullPolicy").equals("Never"));
 	}
 }


### PR DESCRIPTION
 - Some of the K8s deployer properties which have the fixed camel case property names need to be parsed explicitly to allow retrieving the other supported property name keys.
   - Add a utility to parse the camel case property names and retrieve the property values even if any of the supported property name syntax is used
   - Move RelaxedNames util class as it helps find the possible property name combinations
       - The reason to go with this class is simply to fetch all possible combination of property name values and this is different from how property binding works in Spring Boot 2
   - Add tests to showcase the issue

Resolves #328