### PR TITLE
Add dep handling for kubernetes-model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
 				<artifactId>kubernetes-client</artifactId>
 				<version>${kubernetes-client.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>io.fabric8</groupId>
+				<artifactId>kubernetes-model</artifactId>
+				<version>${kubernetes-client.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
- What we're getting from cloud dependencies is
  kubernetes-client-bom-4.4.1.pom which doesn't play nice with our
  pom as we downgrade just kubernetes-client thus getting mixed version
  of kubernetes-model.
- Handling correct version of kubernetes-model don't cause
  compile failures in tests.
- Relates spring-cloud/spring-cloud-dataflow#3670