### PR TITLE
Expose Job specific properties

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class AbstractKubernetesDeployer {
 
 	protected KubernetesClient client;
 
-	protected KubernetesDeployerProperties properties = new KubernetesDeployerProperties();
+	protected KubernetesDeployerProperties properties;
 
 	/**
 	 * Create the RuntimeEnvironmentInfo.

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAutoConfiguration.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,36 +37,39 @@ import org.springframework.core.Ordered;
  * @author Chris Schaefer
  */
 @Configuration
-@EnableConfigurationProperties(KubernetesDeployerProperties.class)
+@EnableConfigurationProperties({KubernetesDeployerProperties.class, KubernetesTaskLauncherProperties.class})
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
 public class KubernetesAutoConfiguration {
 	
 	@Autowired
-	private KubernetesDeployerProperties properties;
+	private KubernetesDeployerProperties deployerProperties;
+
+	@Autowired
+	private KubernetesTaskLauncherProperties taskLauncherProperties;
 
 	@Bean
 	@ConditionalOnMissingBean(AppDeployer.class)
 	public AppDeployer appDeployer(KubernetesClient kubernetesClient,
 	                               ContainerFactory containerFactory) {
-		return new KubernetesAppDeployer(properties, kubernetesClient, containerFactory);
+		return new KubernetesAppDeployer(deployerProperties, kubernetesClient, containerFactory);
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(TaskLauncher.class)
 	public TaskLauncher taskDeployer(KubernetesClient kubernetesClient,
 	                                 ContainerFactory containerFactory) {
-		return new KubernetesTaskLauncher(properties, kubernetesClient, containerFactory);
+		return new KubernetesTaskLauncher(deployerProperties, taskLauncherProperties, kubernetesClient, containerFactory);
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(KubernetesClient.class)
 	public KubernetesClient kubernetesClient() {
-		return KubernetesClientFactory.getKubernetesClient(this.properties);
+		return KubernetesClientFactory.getKubernetesClient(this.deployerProperties);
 	}
 
 	@Bean
 	public ContainerFactory containerFactory() {
-		return new DefaultContainerFactory(properties);
+		return new DefaultContainerFactory(deployerProperties);
 	}
 
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -19,12 +19,12 @@ package org.springframework.cloud.deployer.spi.kubernetes;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.api.model.NodeAffinity;
 import io.fabric8.kubernetes.api.model.PodAffinity;
 import io.fabric8.kubernetes.api.model.PodAntiAffinity;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.client.Config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -72,8 +72,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 
 	@Autowired
 	public KubernetesTaskLauncher(KubernetesDeployerProperties deployerProperties,
-			KubernetesTaskLauncherProperties taskLauncherProperties,
-	                             KubernetesClient client) {
+			KubernetesTaskLauncherProperties taskLauncherProperties, KubernetesClient client) {
 		this(deployerProperties, taskLauncherProperties, client, new DefaultContainerFactory(deployerProperties));
 	}
 
@@ -116,18 +115,14 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 
 			Map<String, String> jobAnnotations = getJobAnnotations(request);
 
-			Map<String, String> jobSpecProperties = new HashMap<>();
-
-			Integer backOffLimit = getBackoffLimit(request);
-
-			if (backOffLimit != null) {
-				jobSpecProperties.put(BACKOFF_LIMIT_KEY, String.valueOf(backOffLimit));
-			}
-
 			podSpec.setRestartPolicy(getRestartPolicy(request).name());
 
 			if (this.properties.isCreateJob()) {
-				launchJob(appId, podSpec, podLabelMap, idMap, jobAnnotations, jobSpecProperties);
+				Integer backOffLimit = getBackoffLimit(request);
+				launchJob(appId, podSpec, podLabelMap, idMap, jobAnnotations,
+						(backOffLimit != null) ?
+								Collections.singletonMap(BACKOFF_LIMIT_KEY, String.valueOf(backOffLimit)) :
+								Collections.EMPTY_MAP);
 			}
 			else {
 				launchPod(appId, podSpec, podLabelMap, idMap, jobAnnotations);

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,34 +24,35 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.batch.Job;
 import io.fabric8.kubernetes.api.model.batch.JobList;
+import io.fabric8.kubernetes.api.model.batch.JobSpec;
+import io.fabric8.kubernetes.api.model.batch.JobSpecBuilder;
+import io.fabric8.kubernetes.api.model.batch.JobStatus;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import org.hashids.Hashids;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.task.LaunchState;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.deployer.spi.task.TaskStatus;
-
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.batch.Job;
-import io.fabric8.kubernetes.api.model.batch.JobSpec;
-import io.fabric8.kubernetes.api.model.batch.JobSpecBuilder;
-import io.fabric8.kubernetes.api.model.batch.JobStatus;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import io.fabric8.kubernetes.api.model.PodStatus;
-import io.fabric8.kubernetes.api.model.PodTemplateSpec;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -61,19 +62,27 @@ import org.springframework.util.StringUtils;
  * @author David Turanski
  * @author Leonardo Diniz
  * @author Chris Schaefer
+ * @author Ilayaperumal Gopinathan
  */
 public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implements TaskLauncher {
 
+	public static final String BACKOFF_LIMIT_KEY = "backoffLimit";
+
+	private KubernetesTaskLauncherProperties taskLauncherProperties;
+
 	@Autowired
-	public KubernetesTaskLauncher(KubernetesDeployerProperties properties,
+	public KubernetesTaskLauncher(KubernetesDeployerProperties deployerProperties,
+			KubernetesTaskLauncherProperties taskLauncherProperties,
 	                             KubernetesClient client) {
-		this(properties, client, new DefaultContainerFactory(properties));
+		this(deployerProperties, taskLauncherProperties, client, new DefaultContainerFactory(deployerProperties));
 	}
 
 	@Autowired
-	public KubernetesTaskLauncher(KubernetesDeployerProperties properties,
+	public KubernetesTaskLauncher(KubernetesDeployerProperties kubernetesDeployerProperties,
+			KubernetesTaskLauncherProperties taskLauncherProperties,
 	                             KubernetesClient client, ContainerFactory containerFactory) {
-		this.properties = properties;
+		this.properties = kubernetesDeployerProperties;
+		this.taskLauncherProperties = taskLauncherProperties;
 		this.client = client;
 		this.containerFactory = containerFactory;
 	}
@@ -107,8 +116,18 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 
 			Map<String, String> jobAnnotations = getJobAnnotations(request);
 
-			if (properties.isCreateJob()) {
-				launchJob(appId, podSpec, podLabelMap, idMap, jobAnnotations);
+			Map<String, String> jobSpecProperties = new HashMap<>();
+
+			Integer backOffLimit = getBackoffLimit(request);
+
+			if (backOffLimit != null) {
+				jobSpecProperties.put(BACKOFF_LIMIT_KEY, String.valueOf(backOffLimit));
+			}
+
+			podSpec.setRestartPolicy(getRestartPolicy(request).name());
+
+			if (this.properties.isCreateJob()) {
+				launchJob(appId, podSpec, podLabelMap, idMap, jobAnnotations, jobSpecProperties);
 			}
 			else {
 				launchPod(appId, podSpec, podLabelMap, idMap, jobAnnotations);
@@ -235,13 +254,17 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 	}
 
 	private void launchJob(String appId, PodSpec podSpec, Map<String, String> podLabelMap, Map<String, String> idMap,
-						   Map<String, String> annotations) {
+						   Map<String, String> annotations, Map<String, String> jobSpecProperties) {
 		ObjectMeta objectMeta = new ObjectMetaBuilder().withLabels(podLabelMap).addToLabels(idMap).build();
 		PodTemplateSpec podTemplateSpec = new PodTemplateSpec(objectMeta, podSpec);
 
 		JobSpec jobSpec = new JobSpecBuilder()
 				.withTemplate(podTemplateSpec)
 				.build();
+
+		if (jobSpecProperties.containsKey(BACKOFF_LIMIT_KEY)) {
+			jobSpec.setBackoffLimit(Integer.valueOf(jobSpecProperties.get(BACKOFF_LIMIT_KEY)));
+		}
 
 		client.batch().jobs()
 				.createNew()
@@ -395,6 +418,41 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 	private Pod getPodByName(String name) {
 		PodResource podResource = client.pods().withName(name);
 		return podResource == null? null: client.pods().withName(name).get();
+	}
+
+	/**
+	 * Get the RestartPolicy setting for the deployment request.
+	 *
+	 * @param request The deployment request.
+	 * @return Whether RestartPolicy is requested
+	 */
+	protected RestartPolicy getRestartPolicy(AppDeploymentRequest request) {
+		String restartPolicyString =
+				PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+						"spring.cloud.deployer.kubernetes.restartPolicy");
+		RestartPolicy restartPolicy =  (StringUtils.isEmpty(restartPolicyString)) ? this.taskLauncherProperties.getRestartPolicy() :
+				RestartPolicy.valueOf(restartPolicyString);
+		if (this.properties.isCreateJob()) {
+			Assert.isTrue(!restartPolicy.equals(RestartPolicy.Always), "RestartPolicy should not be 'Always' when the JobSpec is used.");
+		}
+		return restartPolicy;
+	}
+
+	/**
+	 * Get the BackoffLimit setting for the deployment request.
+	 *
+	 * @param request The deployment request.
+	 * @return the backoffLimit
+	 */
+	protected Integer getBackoffLimit(AppDeploymentRequest request) {
+		String backoffLimitString = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+				"spring.cloud.deployer.kubernetes.backoffLimit");
+		if (StringUtils.hasText(backoffLimitString)) {
+			return Integer.valueOf(backoffLimitString);
+		}
+		else {
+			return this.taskLauncherProperties.getBackoffLimit();
+		}
 	}
 
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherProperties.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the Kubernetes Task Launcher.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@ConfigurationProperties(prefix = "spring.cloud.deployer.kubernetes")
+public class KubernetesTaskLauncherProperties {
+
+	/**
+	 * The {@link RestartPolicy} to use. Defaults to {@link RestartPolicy#Never}.
+	 */
+	private RestartPolicy restartPolicy = RestartPolicy.Never;
+
+	/**
+	 * The backoff limit to specify the number of retries before considering a Job as failed.
+	 */
+	private Integer backoffLimit;
+
+	/**
+	 * Obtains the {@link RestartPolicy} to use. Defaults to
+	 * {@link KubernetesTaskLauncherProperties#restartPolicy}.
+	 *
+	 * @return the {@link RestartPolicy} to use
+	 */
+	public RestartPolicy getRestartPolicy() {
+		return restartPolicy;
+	}
+
+	/**
+	 * Sets the {@link RestartPolicy} to use.
+	 *
+	 * @param restartPolicy the {@link RestartPolicy} to use
+	 */
+	public void setRestartPolicy(RestartPolicy restartPolicy) {
+		this.restartPolicy = restartPolicy;
+	}
+
+	public Integer getBackoffLimit() {
+		return backoffLimit;
+	}
+
+	public void setBackoffLimit(Integer backoffLimit) {
+		this.backoffLimit = backoffLimit;
+	}
+
+
+}

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherProperties.java
@@ -55,13 +55,21 @@ public class KubernetesTaskLauncherProperties {
 		this.restartPolicy = restartPolicy;
 	}
 
+	/**
+	 * Get the BackoffLimit value
+	 * @return the integer value of BackoffLimit
+	 */
 	public Integer getBackoffLimit() {
 		return backoffLimit;
 	}
 
+	/**
+	 * Sets the BackoffLimit.
+	 *
+	 * @param backoffLimit the integer value of BackoffLimit
+	 */
 	public void setBackoffLimit(Integer backoffLimit) {
 		this.backoffLimit = backoffLimit;
 	}
-
 
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/RestartPolicy.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/RestartPolicy.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
+package org.springframework.cloud.deployer.spi.kubernetes;
 
 /**
  * Defines restart policies that are available.
@@ -22,6 +22,12 @@ package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
  * @author Chris Schaefer
  */
 public enum RestartPolicy {
+
+	/**
+	 * Always restart a failed container.
+	 */
+	Always,
+
 	/**
 	 * Restart a failed container with an exponential back-off delay, capped at 5 minutes.
 	 */

--- a/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerProperties.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.deployer.spi.scheduler.kubernetes;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.deployer.spi.kubernetes.EntryPointStyle;
 import org.springframework.cloud.deployer.spi.kubernetes.ImagePullPolicy;
+import org.springframework.cloud.deployer.spi.kubernetes.RestartPolicy;
 import org.springframework.util.StringUtils;
 
 /**

--- a/src/test/java/org/springframework/cloud/deployer/KubernetesTestSupport.java
+++ b/src/test/java/org/springframework/cloud/deployer/KubernetesTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,11 +59,9 @@ public class KubernetesTestSupport extends AbstractExternalResourceTestSupport<K
 
 	@Configuration
 	@EnableAutoConfiguration
-	@EnableConfigurationProperties(KubernetesDeployerProperties.class)
 	public static class Config {
 
-		@Autowired
-		private KubernetesDeployerProperties properties;
+		private KubernetesDeployerProperties properties = new KubernetesDeployerProperties();
 
 		@Bean
 		public KubernetesClient kubernetesClient() {

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,6 @@ import java.util.UUID;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import org.hamcrest.Matchers;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -43,8 +39,12 @@ import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.deployer.spi.task.TaskStatus;
 import org.springframework.cloud.deployer.spi.test.AbstractTaskLauncherIntegrationTests;
 import org.springframework.cloud.deployer.spi.test.Timeout;
-import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
 import org.springframework.core.io.Resource;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.cloud.deployer.spi.test.EventuallyMatcher.eventually;
 
 /**
  * Integration tests for {@link KubernetesTaskLauncher}.
@@ -98,7 +98,7 @@ public class KubernetesTaskLauncherIntegrationTests extends AbstractTaskLauncher
 		log.info("Testing {}...", "JobPodAnnotation");
 
 		KubernetesTaskLauncher kubernetesTaskLauncher = new KubernetesTaskLauncher(new KubernetesDeployerProperties(),
-				kubernetesClient);
+				new KubernetesTaskLauncherProperties(), kubernetesClient);
 
 		AppDefinition definition = new AppDefinition(randomName(), null);
 		Resource resource = testApplication();
@@ -141,4 +141,6 @@ public class KubernetesTaskLauncherIntegrationTests extends AbstractTaskLauncher
 				Matchers.<TaskStatus>hasProperty("state", Matchers.is(LaunchState.unknown))), timeout.maxAttempts,
 				timeout.pause));
 	}
+
+
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherWithJobIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherWithJobIntegrationTests.java
@@ -185,21 +185,19 @@ public class KubernetesTaskLauncherWithJobIntegrationTests extends AbstractTaskL
 
 		log.info("Checking job spec of {}...", taskName);
 
-		List<io.fabric8.kubernetes.api.model.batch.Job> jobs = kubernetesClient.batch().jobs().withLabel("task-name", taskName).list().getItems();
+		List<Job> jobs = kubernetesClient.batch().jobs().withLabel("task-name", taskName).list().getItems();
 
 		assertThat(jobs.size(), is(1));
 
-		io.fabric8.kubernetes.api.model.batch.Job job = jobs.get(0);
-		assertTrue(job.getSpec().getBackoffLimit().equals(5));
+		Job job = jobs.get(0);
+		assertThat(job.getSpec().getBackoffLimit(), is(5));
 
 
-		log.info("Checking job pod spec annotations of {}...", taskName);
+		log.info("Checking pod spec of {}...", taskName);
 
 		List<Pod> pods = kubernetesClient.pods().withLabel("task-name", taskName).list().getItems();
 
 		assertThat(pods.size(), is(1));
-
-		Pod pod = pods.get(0);
 
 		log.info("Destroying {}...", taskName);
 
@@ -214,7 +212,7 @@ public class KubernetesTaskLauncherWithJobIntegrationTests extends AbstractTaskL
 
 	@Test
 	public void testJobSpecWithInvalidRestartPolicy() {
-		log.info("Testing {}...", "JobSpecProperties");
+		log.info("Testing {}...", "JobSpecWithInvalidRestartPolicy");
 
 		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
 		kubernetesDeployerProperties.setCreateJob(true);
@@ -232,7 +230,7 @@ public class KubernetesTaskLauncherWithJobIntegrationTests extends AbstractTaskL
 		log.info("Launching {}...", request.getDefinition().getName());
 
 		try {
-			String launchId = kubernetesTaskLauncher.launch(request);
+			kubernetesTaskLauncher.launch(request);
 			fail("Expected exception as the RestartPolicy Always is not expected to be set for JobSpec.");
 		}
 		catch (Exception e) {

--- a/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerPropertiesTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerPropertiesTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/scheduler/kubernetes/KubernetesSchedulerPropertiesTests.java
@@ -25,6 +25,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.springframework.cloud.deployer.spi.kubernetes.EntryPointStyle;
 import org.springframework.cloud.deployer.spi.kubernetes.ImagePullPolicy;
+import org.springframework.cloud.deployer.spi.kubernetes.RestartPolicy;
 import org.springframework.util.StringUtils;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
 - Add RestartPolicy and BackoffLimit to Pod/Job spec respectively.
 - Add KubernetesTaskLauncherProperties to add these new properties as they are applicable only to task.
 - Update tests

Resolves #337
Resolves #332