### PR TITLE
Binding properties should use relaxed property keys

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
@@ -561,7 +561,7 @@ class DeploymentPropertiesResolver {
 	 */
 	private static KubernetesDeployerProperties bindProperties(Map<String, String> kubernetesDeployerProperties,
 			String propertyKey, String yamlLabel) {
-		String deploymentPropertyValue = kubernetesDeployerProperties.getOrDefault(propertyKey, "");
+		String deploymentPropertyValue = PropertyParserUtils.getDeploymentPropertyValue(kubernetesDeployerProperties, propertyKey);
 
 		KubernetesDeployerProperties deployerProperties = new KubernetesDeployerProperties();
 

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationTests.java
@@ -1532,7 +1532,7 @@ public class KubernetesAppDeployerIntegrationTests extends AbstractAppDeployerIn
 				kubernetesClient);
 
 		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.configMapRefs", configMap.getMetadata().getName());
+		props.put("spring.cloud.deployer.kubernetes.config-map-refs", configMap.getMetadata().getName());
 
 		AppDefinition definition = new AppDefinition(randomName(), null);
 		Resource resource = testApplication();


### PR DESCRIPTION
 - When binding property keys into the K8s deployer properties, check for all possible relaxed names.
 - Update test

Resolves #393