### PR TITLE
Add job annotations into cron job builder

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesScheduler.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesScheduler.java
@@ -181,7 +181,8 @@ public class KubernetesScheduler extends AbstractKubernetesDeployer implements S
 		}
 
 		CronJob cronJob = new CronJobBuilder().withNewMetadata().withName(scheduleRequest.getScheduleName())
-				.withLabels(labels).endMetadata().withNewSpec().withSchedule(schedule).withNewJobTemplate()
+				.withLabels(labels).withAnnotations(this.deploymentPropertiesResolver.getJobAnnotations(schedulerProperties)).endMetadata()
+				.withNewSpec().withSchedule(schedule).withNewJobTemplate()
 				.withNewSpec().withNewTemplate().withSpec(podSpec).endTemplate().endSpec()
 				.endJobTemplate().endSpec().build();
 


### PR DESCRIPTION
 - Add jobAnnotations by resolving against all the property sources including the Scheduler Properties from the server config
 - Add integration tests to verify the property overriding at the server/deployment levels

Resolves #389