### PR TITLE
Consistent Kubernetes service object naming

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -66,6 +66,8 @@ public class AbstractKubernetesDeployer {
 	protected static final String SPRING_APP_KEY = "spring-app-id";
 	protected static final String SPRING_MARKER_KEY = "role";
 	protected static final String SPRING_MARKER_VALUE = "spring-app";
+	protected static final String APP_NAME_PROPERTY_KEY = AppDeployer.PREFIX + "appName";
+	protected static final String APP_NAME_KEY = "spring-application-name";
 
 	private static final String SERVER_PORT_KEY = "server.port";
 
@@ -115,6 +117,14 @@ public class AbstractKubernetesDeployer {
 			map.put(SPRING_GROUP_KEY, groupId);
 		}
 		map.put(SPRING_DEPLOYMENT_KEY, appId);
+
+		// un-versioned app name provided by skipper
+		String appName = request.getDeploymentProperties().get(APP_NAME_PROPERTY_KEY);
+
+		if (StringUtils.hasText(appName)) {
+			map.put(APP_NAME_KEY, appName);
+		}
+
 		return map;
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-skipper/issues/953

While an issue that is due to Skipper's versioning, there was more flexibility to handle these cases in deployer...

Depends on Skipper built with https://github.com/spring-cloud/spring-cloud-skipper/pull/977/ so we can get the actual non-versioned app name..

Below are the test case steps I have tested this with. Seems to cover the basis that's been discussed. AT's other other testing may reveal other issues...

1. deploy scdf 2.6.1, skipper 2.5.1 releases:
  * app register --name log --type sink --uri docker://springcloudstream/log-sink-rabbit:2.1.3.RELEASE
  * app register --name time --type source --uri docker://springcloudstream/time-source-rabbit:2.1.3.RELEASE
  * create a stream
    * stream create --name ticktock --definition "time | log" --deploy
  * see versioned svc

2. test stream from prior release:
  * upgrade scdf to 2.7.0-SNAPSHOT, skipper to 2.6.0-SNAPSHOT
  * upgrade log:
    * app register --name log --type sink --uri docker://springcloudstream/log-sink-rabbit:2.1.4.RELEASE
    * stream update --name ticktock --properties version.log=2.1.4.RELEASE
  * the versioned svc should still be there
  * rollback:
    * stream rollback --name ticktock
  * verify versioned still there
  * destroy:
    * stream all destroy
    * verify everything is deleted
    * app all unregister

3. test stream created with a name of prior deleted stream from case 1 & 2 (ticktock)
  * app register --name log --type sink --uri docker://springcloudstream/log-sink-rabbit:2.1.3.RELEASE
  * app register --name time --type source --uri docker://springcloudstream/time-source-rabbit:2.1.3.RELEASE
  * create a stream
    * stream create --name ticktock --definition "time | log" --deploy
  * verify unversioned svc
  * upgrade log:
    * app register --name log --type sink --uri docker://springcloudstream/log-sink-rabbit:2.1.4.RELEASE
    * stream update --name ticktock --properties version.log=2.1.4.RELEASE
  * rollback:
    * stream rollback --name ticktock
  * verify unversioned
  * destroy:
    * stream all destroy
	* verify everything is deleted
    * app all unregister

4. create "fresh" stream, delete it, recreate it again, delete
  * app register --name log --type sink --uri docker://springcloudstream/log-sink-rabbit:2.1.3.RELEASE
  * app register --name time --type source --uri docker://springcloudstream/time-source-rabbit:2.1.3.RELEASE
  * create a stream
    * stream create --name ticktock55 --definition "time | log" --deploy
  * verify unversioned svc
   * upgrade log:
    * app register --name log --type sink --uri docker://springcloudstream/log-sink-rabbit:2.1.4.RELEASE
    * stream update --name ticktock55 --properties version.log=2.1.4.RELEASE
  * rollback:
    * stream rollback --name ticktock55
  * verify unversioned
  * destroy:
    * stream all destroy
	* verify everything is deleted
    * app all unregister
  * repeat from step 1 once more
 