### PR TITLE
Converting cmd line args in shell mode doesn't respect cmd args not prefixed with --

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -126,7 +126,14 @@ public class DefaultContainerFactory implements ContainerFactory {
 			// The task app name(in case of Composed Task), platform_name and executionId are expected to be updated.
 			// This will also override any of the existing app properties that match the provided cmdline args.
 			for (String cmdLineArg: request.getCommandlineArguments()) {
-				String cmdLineArgKey = cmdLineArg.substring(2, cmdLineArg.indexOf("="));
+				String cmdLineArgKey;
+
+				if (cmdLineArg.startsWith("--")) {
+					cmdLineArgKey = cmdLineArg.substring(2, cmdLineArg.indexOf("="));
+				} else {
+					cmdLineArgKey = cmdLineArg.substring(0, cmdLineArg.indexOf("="));
+				}
+
 				String cmdLineArgValue = cmdLineArg.substring(cmdLineArg.indexOf("=") + 1);
 				envVarsMap.put(cmdLineArgKey.replace('.', '_').toUpperCase(), cmdLineArgValue);
 			}

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
@@ -210,13 +210,14 @@ public class DefaultContainerFactoryTests {
 		cmdLineArgs.add("--spring.cloud.task.executionid=1");
 		cmdLineArgs.add("--spring.cloud.data.flow.platformname=platform1");
 		cmdLineArgs.add("--spring.cloud.data.flow.taskappname==a1");
+		cmdLineArgs.add("blah=chacha");
 		appDeploymentRequestShell = new AppDeploymentRequest(definition,
 				resource, props, cmdLineArgs);
 		shellContainerConfiguration = new ContainerConfiguration("app-test",
 				appDeploymentRequestShell);
 		containerShell = defaultContainerFactory.create(shellContainerConfiguration);
 		assertNotNull(containerShell);
-		assertTrue(containerShell.getEnv().size() == 6);
+		assertTrue(containerShell.getEnv().size() == 7);
 		assertTrue(containerShell.getArgs().size() == 0);
 		String envVarString = containerShell.getEnv().toString();
 		assertTrue(envVarString.contains("name=FOO_BAR_BAZ, value=test"));
@@ -224,6 +225,7 @@ public class DefaultContainerFactoryTests {
 		assertTrue(envVarString.contains("name=SPRING_CLOUD_TASK_EXECUTIONID, value=1"));
 		assertTrue(envVarString.contains("name=SPRING_CLOUD_DATA_FLOW_TASKAPPNAME, value==a1"));
 		assertTrue(envVarString.contains("name=SPRING_CLOUD_DATA_FLOW_PLATFORMNAME, value=platform1"));
+		assertTrue(envVarString.contains("name=BLAH, value=chacha"));
 
 		props.put("spring.cloud.deployer.kubernetes.entryPointStyle", "exec");
 		AppDeploymentRequest appDeploymentRequestExec = new AppDeploymentRequest(definition,


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/issues/404