### PR TITLE
GH-4294 Register multiple imagePullSecrets

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.deployer.spi.kubernetes;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -186,6 +187,12 @@ public class AbstractKubernetesDeployer {
 
 		if (imagePullSecret != null) {
 			podSpec.addNewImagePullSecret(imagePullSecret);
+		}
+		
+		List<String> imagePullSecrets = this.deploymentPropertiesResolver.getImagePullSecrets(deploymentProperties);
+
+		if (imagePullSecrets != null) {			
+			imagePullSecrets.forEach(imgPullsecret -> podSpec.addNewImagePullSecret(imgPullsecret));
 		}
 
 		boolean hostNetwork = this.deploymentPropertiesResolver.getHostNetwork(deploymentProperties);

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
@@ -365,6 +365,18 @@ class DeploymentPropertiesResolver {
 		return imagePullSecret;
 	}
 
+	List<String> getImagePullSecrets(Map<String, String> kubernetesDeployerProperties) {
+
+		KubernetesDeployerProperties deployerProperties = bindProperties(kubernetesDeployerProperties,
+				this.propertyPrefix + ".imagePullSecrets", "imagePullSecrets");
+
+		if (deployerProperties.getImagePullSecrets() == null || deployerProperties.getImagePullSecrets().isEmpty()) {
+			return properties.getImagePullSecrets();
+		} else {
+			return deployerProperties.getImagePullSecrets();
+		}
+	}
+
 	String getDeploymentServiceAccountName(Map<String, String> kubernetesDeployerProperties) {
 		String deploymentServiceAccountName = PropertyParserUtils.getDeploymentPropertyValue(kubernetesDeployerProperties,
 				this.propertyPrefix + ".deploymentServiceAccountName");

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -398,6 +398,11 @@ public class KubernetesDeployerProperties {
 	 * Secrets for a access a private registry to pull images.
 	 */
 	private String imagePullSecret;
+	
+	/**
+	 * List of Secrets for a access a private registry to pull images.
+	 */
+	private List<String> imagePullSecrets;
 
 	/**
 	 * Delay in seconds when the Kubernetes liveness check of the app container
@@ -696,6 +701,14 @@ public class KubernetesDeployerProperties {
 
 	public void setImagePullSecret(String imagePullSecret) {
 		this.imagePullSecret = imagePullSecret;
+	}
+	
+	public List<String> getImagePullSecrets() {
+		return imagePullSecrets;
+	}
+
+	public void setImagePullSecrets(List<String> imagePullSecrets) {
+		this.imagePullSecrets = imagePullSecrets;
 	}
 
 	/**

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -261,6 +261,40 @@ public class KubernetesAppDeployerTests {
 		assertThat(podSpec.getImagePullSecrets().size()).isEqualTo(1);
 		assertThat(podSpec.getImagePullSecrets().get(0).getName()).isEqualTo("regcred");
 	}
+	
+	@Test
+	public void deployWithImagePullSecretsDeploymentProperty() {
+		AppDefinition definition = new AppDefinition("app-test", null);
+
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.imagePullSecrets", "['regcredone','regcredtwo']");
+
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		assertThat(podSpec.getImagePullSecrets().size()).isEqualTo(2);
+		assertThat(podSpec.getImagePullSecrets().get(0).getName()).isEqualTo("regcredone");
+		assertThat(podSpec.getImagePullSecrets().get(1).getName()).isEqualTo("regcredtwo");
+	}
+
+	@Test
+	public void deployWithImagePullSecretsDeployerProperty() {
+		AppDefinition definition = new AppDefinition("app-test", null);
+
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
+
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setImagePullSecrets(Arrays.asList("regcredone","regcredtwo"));
+
+		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		assertThat(podSpec.getImagePullSecrets().size()).isEqualTo(2);
+		assertThat(podSpec.getImagePullSecrets().get(0).getName()).isEqualTo("regcredone");
+		assertThat(podSpec.getImagePullSecrets().get(1).getName()).isEqualTo("regcredtwo");
+	}
 
 	@Test
 	public void deployWithDeploymentServiceAccountNameDeploymentProperties() {


### PR DESCRIPTION
Changes made to enable supplying multiple image pull secrets for Kubernetes