### PR TITLE
KubernetesScheduler. Avoiding NPE thrown from exception handling code

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesScheduler.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesScheduler.java
@@ -193,6 +193,9 @@ public class KubernetesScheduler extends AbstractKubernetesDeployer implements S
 
 	protected String getExceptionMessageForField(KubernetesClientException clientException,
 			String fieldName) {
+		if (clientException.getStatus() == null || clientException.getStatus().getDetails() == null) {
+			return null;
+		}
 		List<StatusCause> statusCauses = clientException.getStatus().getDetails().getCauses();
 
 		if (!CollectionUtils.isEmpty(statusCauses)) {


### PR DESCRIPTION
During testing of SCDF 2.7.1, which uses  spring-cloud-deployer-kubernetes 2.5.1, we've run into an exception with the following stack trace. The original exception, which is caught at `KubernetesScheduler.java:79` is lost

```
2021-02-02 12:58:18.888 ERROR 1 --- [nio-8080-exec-7] o.s.c.d.s.c.RestControllerAdvice         : Caught exception while handling a request
java.lang.NullPointerException: null
	at org.springframework.cloud.deployer.spi.kubernetes.KubernetesScheduler.getExceptionMessageForField(KubernetesScheduler.java:196)
	at org.springframework.cloud.deployer.spi.kubernetes.KubernetesScheduler.schedule(KubernetesScheduler.java:79)
	at org.springframework.cloud.dataflow.server.service.impl.DefaultSchedulerService.schedule(DefaultSchedulerService.java:233)
	at org.springframework.cloud.dataflow.server.controller.TaskSchedulerController.save(TaskSchedulerController.java:162)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:190)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:138)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:105)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:878)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:792)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1040)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:943)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:909)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:652)
```