### PR TITLE
Enable Http probe scheme configuration

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/HttpProbeCreator.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/HttpProbeCreator.java
@@ -42,6 +42,7 @@ public abstract class HttpProbeCreator extends ProbeCreator {
 	static final String BOOT_1_LIVENESS_PROBE_PATH = "/health";
 	static final String BOOT_2_READINESS_PROBE_PATH = "/actuator" + BOOT_1_READINESS_PROBE_PATH;
 	static final String BOOT_2_LIVENESS_PROBE_PATH = "/actuator" + BOOT_1_LIVENESS_PROBE_PATH;
+	static final String DEFAULT_PROBE_SCHEME = "HTTP";
 
 	HttpProbeCreator(KubernetesDeployerProperties kubernetesDeployerProperties,
 					 ContainerConfiguration containerConfiguration) {
@@ -52,12 +53,15 @@ public abstract class HttpProbeCreator extends ProbeCreator {
 
 	protected abstract Integer getPort();
 
+	protected abstract String getScheme();
+
 	protected abstract int getTimeout();
 
 	protected Probe create() {
 		HTTPGetActionBuilder httpGetActionBuilder = new HTTPGetActionBuilder()
 				.withPath(getProbePath())
-				.withNewPort(getPort());
+				.withNewPort(getPort())
+				.withScheme(getScheme());
 
 		List<HTTPHeader> httpHeaders = getHttpHeaders();
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.deployer.spi.kubernetes;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.NodeAffinity;
 import io.fabric8.kubernetes.api.model.PodAffinity;
 import io.fabric8.kubernetes.api.model.PodAntiAffinity;
@@ -436,6 +437,16 @@ public class KubernetesDeployerProperties {
 	 * Port that app container has to respond on for liveness check.
 	 */
 	private Integer livenessHttpProbePort = null;
+
+	/**
+	 * Schema that app container has to respond on for liveness check.
+	 */
+	private String livenessHttpProbeScheme = "HTTP";
+
+	/**
+	 * Schema that app container has to respond to for readiness check.
+	 */
+	private String readinessHttpProbeScheme = "HTTP";
 
 	/**
 	 * Delay in seconds when the readiness check of the app container
@@ -1329,5 +1340,21 @@ public class KubernetesDeployerProperties {
 
 	public void setAdditionalContainers(List<Container> additionalContainers) {
 		this.additionalContainers = additionalContainers;
+	}
+
+	public String getLivenessHttpProbeScheme() {
+		return livenessHttpProbeScheme;
+	}
+
+	public void setLivenessHttpProbeScheme(String livenessHttpProbeScheme) {
+		this.livenessHttpProbeScheme = livenessHttpProbeScheme;
+	}
+
+	public String getReadinessHttpProbeScheme() {
+		return readinessHttpProbeScheme;
+	}
+
+	public void setReadinessHttpProbeScheme(String readinessHttpProbeScheme) {
+		this.readinessHttpProbeScheme = readinessHttpProbeScheme;
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/LivenessHttpProbeCreator.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/LivenessHttpProbeCreator.java
@@ -69,6 +69,21 @@ class LivenessHttpProbeCreator extends HttpProbeCreator {
 	}
 
 	@Override
+	protected String getScheme() {
+		String probeSchemeValue = getProbePropertyName(LIVENESS_DEPLOYER_PROPERTY_PREFIX, "ProbeScheme");
+
+		if (StringUtils.hasText(probeSchemeValue)) {
+			return probeSchemeValue;
+		}
+
+		if (getKubernetesDeployerProperties().getLivenessHttpProbeScheme() != null) {
+			return getKubernetesDeployerProperties().getLivenessHttpProbeScheme();
+		}
+
+		return DEFAULT_PROBE_SCHEME;
+	}
+
+	@Override
 	protected int getTimeout() {
 		String probeTimeoutValue = getProbePropertyName(LIVENESS_DEPLOYER_PROPERTY_PREFIX, "ProbeTimeout");
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ReadinessHttpProbeCreator.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/ReadinessHttpProbeCreator.java
@@ -73,6 +73,21 @@ class ReadinessHttpProbeCreator extends HttpProbeCreator {
 	}
 
 	@Override
+	protected String getScheme() {
+		String probeSchemeValue = getProbePropertyName(READINESS_DEPLOYER_PROPERTY_PREFIX, "ProbeScheme");
+
+		if (StringUtils.hasText(probeSchemeValue)) {
+			return probeSchemeValue;
+		}
+
+		if (getKubernetesDeployerProperties().getReadinessHttpProbeScheme() != null) {
+			return getKubernetesDeployerProperties().getReadinessHttpProbeScheme();
+		}
+
+		return DEFAULT_PROBE_SCHEME;
+	}
+
+	@Override
 	protected int getTimeout() {
 		String probeTimeoutValue = getProbePropertyName(READINESS_DEPLOYER_PROPERTY_PREFIX, "ProbeTimeout");
 

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
@@ -369,6 +369,93 @@ public class DefaultContainerFactoryTests {
 		assertEquals(8090, (int) container.getLivenessProbe().getHttpGet().getPort().getIntVal());
 	}
 
+	@Test
+	public void createCustomLivenessHttpProbeSchemeFromProperties() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setLivenessHttpProbeScheme("HTTPS");
+		DefaultContainerFactory defaultContainerFactory = new DefaultContainerFactory(
+				kubernetesDeployerProperties);
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		Resource resource = getResource();
+		Map<String, String> props = new HashMap<>();
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition,
+				resource, props);
+
+		ContainerConfiguration containerConfiguration = new ContainerConfiguration("app-test", appDeploymentRequest)
+				.withExternalPort(8080)
+				.withHostNetwork(true);
+		Container container = defaultContainerFactory.create(containerConfiguration);
+		assertNotNull(container);
+
+		List<ContainerPort> containerPorts = container.getPorts();
+		assertNotNull(containerPorts);
+
+		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
+		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
+		assertEquals(8080, (int) container.getLivenessProbe().getHttpGet().getPort().getIntVal());
+		assertEquals("HTTPS", container.getLivenessProbe().getHttpGet().getScheme());
+	}
+
+	@Test
+	public void createCustomReadinessHttpSchemeFromProperties() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setReadinessHttpProbeScheme("HTTPS");
+		DefaultContainerFactory defaultContainerFactory = new DefaultContainerFactory(
+				kubernetesDeployerProperties);
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		Resource resource = getResource();
+		Map<String, String> props = new HashMap<>();
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition,
+				resource, props);
+
+		ContainerConfiguration containerConfiguration = new ContainerConfiguration("app-test", appDeploymentRequest)
+				.withHostNetwork(true)
+				.withExternalPort(8080);
+		Container container = defaultContainerFactory.create(containerConfiguration);
+		assertNotNull(container);
+
+		List<ContainerPort> containerPorts = container.getPorts();
+		assertNotNull(containerPorts);
+
+		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
+		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
+		assertEquals(8080, (int) container.getReadinessProbe().getHttpGet().getPort().getIntVal());
+		assertEquals("HTTPS", container.getReadinessProbe().getHttpGet().getScheme());
+	}
+
+	@Test
+	public void createCustomLivenessAndReadinessHttpProbeSchemeFromAppRequest() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		DefaultContainerFactory defaultContainerFactory = new DefaultContainerFactory(
+				kubernetesDeployerProperties);
+
+		Map<String,String> appProperties = new HashMap<>();
+		appProperties.put("spring.cloud.deployer.kubernetes.livenessHttpProbeScheme", "HTTPS");
+		appProperties.put("spring.cloud.deployer.kubernetes.readinessHttpProbeScheme", "HTTPS");
+
+		AppDefinition definition = new AppDefinition("app-test", appProperties);
+		Resource resource = getResource();
+
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition,
+				resource, appProperties);
+
+		ContainerConfiguration containerConfiguration = new ContainerConfiguration("app-test", appDeploymentRequest)
+				.withHostNetwork(true)
+				.withExternalPort(8080);
+
+		Container container = defaultContainerFactory.create(containerConfiguration);
+
+		assertNotNull(container);
+
+		assertNotNull(container.getReadinessProbe().getHttpGet().getPath());
+		assertEquals("HTTPS", container.getReadinessProbe().getHttpGet().getScheme());
+
+		assertNotNull(container.getLivenessProbe().getHttpGet().getPath());
+		assertEquals("HTTPS", container.getLivenessProbe().getHttpGet().getScheme());
+	}
+
 	/**
 	 * @deprecated {@see {@link #createCustomLivenessHttpPortFromAppRequest()}}
 	 */


### PR DESCRIPTION
 - Allow configuring the livenessProbe.scheme with livenessHttpProbeScheme and readinessProbe.scheme with he readinessHttpProbeScheme properties.
 - Scheme defaults to HTTP. But can be set to HTTPS for SSL applications.