### PR TITLE
Convert tests to junit5

### DIFF
--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,21 +37,18 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.resource.docker.DockerResource;
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.core.io.Resource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for {@link DefaultContainerFactory}.
@@ -62,7 +59,7 @@ import static org.junit.Assert.fail;
  * @author David Turanski
  * @author Ilayaperumal Gopinathan
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { KubernetesAutoConfiguration.class })
 public class DefaultContainerFactoryTests {
 
@@ -83,14 +80,14 @@ public class DefaultContainerFactoryTests {
 
 		ContainerConfiguration containerConfiguration = new ContainerConfiguration("app-test", appDeploymentRequest);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
-		assertEquals(3, container.getEnv().size());
+		assertThat(container).isNotNull();
+		assertThat(container.getEnv().size()).isEqualTo(3);
 		EnvVar envVar1 = container.getEnv().get(0);
 		EnvVar envVar2 = container.getEnv().get(1);
-		assertEquals("JAVA_OPTIONS", envVar1.getName());
-		assertEquals("-Xmx64m", envVar1.getValue());
-		assertEquals("KUBERNETES_NAMESPACE", envVar2.getName());
-		assertEquals("test-space", envVar2.getValue());
+		assertThat(envVar1.getName()).isEqualTo("JAVA_OPTIONS");
+		assertThat(envVar1.getValue()).isEqualTo("-Xmx64m");
+		assertThat(envVar2.getName()).isEqualTo("KUBERNETES_NAMESPACE");
+		assertThat(envVar2.getValue()).isEqualTo("test-space");
 	}
 
 	@Test
@@ -109,7 +106,7 @@ public class DefaultContainerFactoryTests {
 
 		ContainerConfiguration containerConfiguration = new ContainerConfiguration("app-test", appDeploymentRequest);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 		assertThat(container.getCommand()).containsExactly("echo", "arg1", "arg2");
 	}
 
@@ -129,16 +126,16 @@ public class DefaultContainerFactoryTests {
 
 		ContainerConfiguration containerConfiguration = new ContainerConfiguration("app-test", appDeploymentRequest);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
-		assertTrue("There should be three ports set", containerPorts.size() == 3);
-		assertTrue(8081 == containerPorts.get(0).getContainerPort());
-		assertTrue(8082 == containerPorts.get(1).getContainerPort());
-		assertTrue(65535 == containerPorts.get(2).getContainerPort());
+		assertThat(containerPorts).isNotNull();
+		assertThat(containerPorts.size()).isEqualTo(3);
+		assertThat(containerPorts.get(0).getContainerPort()).isEqualTo(8081);
+		assertThat(containerPorts.get(1).getContainerPort()).isEqualTo(8082);
+		assertThat(containerPorts.get(2).getContainerPort()).isEqualTo(65535);
 	}
 
-	@Test(expected = NumberFormatException.class)
+	@Test
 	public void createWithInvalidPort() {
 		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
 		DefaultContainerFactory defaultContainerFactory = new DefaultContainerFactory(
@@ -154,7 +151,9 @@ public class DefaultContainerFactoryTests {
 
 		//Attempting to create with an invalid integer set for a port should cause an exception to bubble up.
 		ContainerConfiguration containerConfiguration = new ContainerConfiguration("app-test", appDeploymentRequest);
-		defaultContainerFactory.create(containerConfiguration);
+		assertThatThrownBy(() -> {
+			defaultContainerFactory.create(containerConfiguration);
+		}).isInstanceOf(NumberFormatException.class);
 	}
 
 	@Test
@@ -174,16 +173,16 @@ public class DefaultContainerFactoryTests {
 		ContainerConfiguration containerConfiguration = new ContainerConfiguration("app-test", appDeploymentRequest)
 				.withHostNetwork(true);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
-		assertTrue("There should be three container ports set", containerPorts.size() == 3);
-		assertTrue(8081 == containerPorts.get(0).getContainerPort());
-		assertTrue(8081 == containerPorts.get(0).getHostPort());
-		assertTrue(8082 == containerPorts.get(1).getContainerPort());
-		assertTrue(8082 == containerPorts.get(1).getHostPort());
-		assertTrue(65535 == containerPorts.get(2).getContainerPort());
-		assertTrue(65535 == containerPorts.get(2).getHostPort());
+		assertThat(containerPorts).isNotNull();
+		assertThat(containerPorts.size()).isEqualTo(3);
+		assertThat(containerPorts.get(0).getContainerPort()).isEqualTo(8081);
+		assertThat(containerPorts.get(0).getHostPort()).isEqualTo(8081);
+		assertThat(containerPorts.get(1).getContainerPort()).isEqualTo(8082);
+		assertThat(containerPorts.get(1).getHostPort()).isEqualTo(8082);
+		assertThat(containerPorts.get(2).getContainerPort()).isEqualTo(65535);
+		assertThat(containerPorts.get(2).getHostPort()).isEqualTo(65535);
 	}
 
 	@Test
@@ -204,9 +203,10 @@ public class DefaultContainerFactoryTests {
 		ContainerConfiguration shellContainerConfiguration = new ContainerConfiguration("app-test",
 				appDeploymentRequestShell);
 		Container containerShell = defaultContainerFactory.create(shellContainerConfiguration);
-		assertNotNull(containerShell);
-		assertTrue(containerShell.getEnv().get(0).getName().equals("FOO_BAR_BAZ"));
-		assertTrue(containerShell.getArgs().size() == 0);
+		assertThat(containerShell).isNotNull();
+
+		assertThat(containerShell.getEnv().get(0).getName()).isEqualTo("FOO_BAR_BAZ");
+		assertThat(containerShell.getArgs()).isEmpty();
 
 		List<String> cmdLineArgs = new ArrayList<>();
 		cmdLineArgs.add("--foo.bar=value1");
@@ -219,16 +219,16 @@ public class DefaultContainerFactoryTests {
 		shellContainerConfiguration = new ContainerConfiguration("app-test",
 				appDeploymentRequestShell);
 		containerShell = defaultContainerFactory.create(shellContainerConfiguration);
-		assertNotNull(containerShell);
-		assertTrue(containerShell.getEnv().size() == 7);
-		assertTrue(containerShell.getArgs().size() == 0);
+		assertThat(containerShell).isNotNull();
+		assertThat(containerShell.getEnv()).hasSize(7);
+		assertThat(containerShell.getArgs()).isEmpty();
 		String envVarString = containerShell.getEnv().toString();
-		assertTrue(envVarString.contains("name=FOO_BAR_BAZ, value=test"));
-		assertTrue(envVarString.contains("name=FOO_BAR, value=value1"));
-		assertTrue(envVarString.contains("name=SPRING_CLOUD_TASK_EXECUTIONID, value=1"));
-		assertTrue(envVarString.contains("name=SPRING_CLOUD_DATA_FLOW_TASKAPPNAME, value==a1"));
-		assertTrue(envVarString.contains("name=SPRING_CLOUD_DATA_FLOW_PLATFORMNAME, value=platform1"));
-		assertTrue(envVarString.contains("name=BLAH, value=chacha"));
+		assertThat(envVarString.contains("name=FOO_BAR_BAZ, value=test")).isTrue();
+		assertThat(envVarString.contains("name=FOO_BAR, value=value1")).isTrue();
+		assertThat(envVarString.contains("name=SPRING_CLOUD_TASK_EXECUTIONID, value=1")).isTrue();
+		assertThat(envVarString.contains("name=SPRING_CLOUD_DATA_FLOW_TASKAPPNAME, value==a1")).isTrue();
+		assertThat(envVarString.contains("name=SPRING_CLOUD_DATA_FLOW_PLATFORMNAME, value=platform1")).isTrue();
+		assertThat(envVarString.contains("name=BLAH, value=chacha")).isTrue();
 
 		props.put("spring.cloud.deployer.kubernetes.entryPointStyle", "exec");
 		AppDeploymentRequest appDeploymentRequestExec = new AppDeploymentRequest(definition,
@@ -236,9 +236,9 @@ public class DefaultContainerFactoryTests {
 		ContainerConfiguration execContainerConfiguration = new ContainerConfiguration("app-test",
 				appDeploymentRequestExec);
 		Container containerExec = defaultContainerFactory.create(execContainerConfiguration);
-		assertNotNull(containerExec);
-		assertTrue(containerExec.getEnv().size() == 1);
-		assertTrue(containerExec.getArgs().get(0).equals("--foo.bar.baz=test"));
+		assertThat(containerExec).isNotNull();
+		assertThat(containerExec.getEnv()).hasSize(1);
+		assertThat(containerExec.getArgs().get(0)).isEqualTo("--foo.bar.baz=test");
 
 		props.put("spring.cloud.deployer.kubernetes.entryPointStyle", "boot");
 		AppDeploymentRequest appDeploymentRequestBoot = new AppDeploymentRequest(definition,
@@ -246,12 +246,12 @@ public class DefaultContainerFactoryTests {
 		ContainerConfiguration bootContainerConfiguration = new ContainerConfiguration("app-test",
 				appDeploymentRequestBoot);
 		Container containerBoot = defaultContainerFactory.create(bootContainerConfiguration);
-		assertNotNull(containerBoot);
-		assertTrue(containerBoot.getEnv().get(0).getName().equals("SPRING_APPLICATION_JSON"));
-		assertTrue(containerBoot.getEnv().get(0).getValue().equals(new ObjectMapper().writeValueAsString(appProps)));
-		assertTrue(containerBoot.getArgs().size() == 2);
-		assertTrue(containerBoot.getArgs().get(0).equals("--arg1=val1"));
-		assertTrue(containerBoot.getArgs().get(1).equals("--arg2=val2"));
+		assertThat(containerBoot).isNotNull();
+		assertThat(containerBoot.getEnv().get(0).getName()).isEqualTo("SPRING_APPLICATION_JSON");
+		assertThat(containerBoot.getEnv().get(0).getValue()).isEqualTo(new ObjectMapper().writeValueAsString(appProps));
+		assertThat(containerBoot.getArgs()).hasSize(2);
+		assertThat(containerBoot.getArgs().get(0)).isEqualTo("--arg1=val1");
+		assertThat(containerBoot.getArgs().get(1)).isEqualTo("--arg2=val2");
 	}
 
 	@Test
@@ -326,17 +326,17 @@ public class DefaultContainerFactoryTests {
 				.withExternalPort(8080)
 				.withHostNetwork(true);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
+		assertThat(containerPorts).isNotNull();
 
-		assertEquals("Only two container ports should be set", 2, containerPorts.size());
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8090, (int) containerPorts.get(1).getContainerPort());
-		assertEquals(8090, (int) containerPorts.get(1).getHostPort());
-		assertEquals(8090, (int) container.getLivenessProbe().getHttpGet().getPort().getIntVal());
+		assertThat(containerPorts).as("Only two container ports should be set").hasSize(2);
+		assertThat((int) containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat((int) containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat((int) containerPorts.get(1).getContainerPort()).isEqualTo(8090);
+		assertThat((int) containerPorts.get(1).getHostPort()).isEqualTo(8090);
+		assertThat((int) container.getLivenessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8090);
 	}
 
 	@Test
@@ -356,17 +356,17 @@ public class DefaultContainerFactoryTests {
 				.withExternalPort(8080)
 				.withHostNetwork(true);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
+		assertThat(containerPorts).isNotNull();
 
-		assertEquals("Only two container ports should be set", 2, containerPorts.size());
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8090, (int) containerPorts.get(1).getContainerPort());
-		assertEquals(8090, (int) containerPorts.get(1).getHostPort());
-		assertEquals(8090, (int) container.getLivenessProbe().getHttpGet().getPort().getIntVal());
+		assertThat(containerPorts).as("Only two container ports should be set").hasSize(2);
+		assertThat((int) containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat((int) containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat((int) containerPorts.get(1).getContainerPort()).isEqualTo(8090);
+		assertThat((int) containerPorts.get(1).getHostPort()).isEqualTo(8090);
+		assertThat((int) container.getLivenessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8090);
 	}
 
 	@Test
@@ -386,15 +386,15 @@ public class DefaultContainerFactoryTests {
 				.withExternalPort(8080)
 				.withHostNetwork(true);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
+		assertThat(containerPorts).isNotNull();
 
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8080, (int) container.getLivenessProbe().getHttpGet().getPort().getIntVal());
-		assertEquals("HTTPS", container.getLivenessProbe().getHttpGet().getScheme());
+		assertThat((int) containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat((int) containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat((int) container.getLivenessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8080);
+		assertThat(container.getLivenessProbe().getHttpGet().getScheme()).isEqualTo("HTTPS");
 	}
 
 	@Test
@@ -414,15 +414,15 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
+		assertThat(containerPorts).isNotNull();
 
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8080, (int) container.getReadinessProbe().getHttpGet().getPort().getIntVal());
-		assertEquals("HTTPS", container.getReadinessProbe().getHttpGet().getScheme());
+		assertThat((int) containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat((int) containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat((int) container.getReadinessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8080);
+		assertThat(container.getReadinessProbe().getHttpGet().getScheme()).isEqualTo("HTTPS");
 	}
 
 	@Test
@@ -447,13 +447,13 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
-		assertNotNull(container.getReadinessProbe().getHttpGet().getPath());
-		assertEquals("HTTPS", container.getReadinessProbe().getHttpGet().getScheme());
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getReadinessProbe().getHttpGet().getScheme()).isEqualTo("HTTPS");
 
-		assertNotNull(container.getLivenessProbe().getHttpGet().getPath());
-		assertEquals("HTTPS", container.getLivenessProbe().getHttpGet().getScheme());
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getLivenessProbe().getHttpGet().getScheme()).isEqualTo("HTTPS");
 	}
 
 	/**
@@ -477,17 +477,17 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
+		assertThat(containerPorts).isNotNull();
 
-		assertEquals("Only two container ports should be set", 2, containerPorts.size());
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8090, (int) containerPorts.get(1).getContainerPort());
-		assertEquals(8090, (int) containerPorts.get(1).getHostPort());
-		assertEquals(8090, (int) container.getLivenessProbe().getHttpGet().getPort().getIntVal());
+		assertThat(containerPorts).hasSize(2);
+		assertThat(containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(1).getContainerPort()).isEqualTo(8090);
+		assertThat(containerPorts.get(1).getHostPort()).isEqualTo(8090);
+		assertThat(container.getLivenessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8090);
 	}
 
 	@Test
@@ -507,17 +507,17 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
+		assertThat(containerPorts).isNotNull();
 
-		assertEquals("Only two container ports should be set", 2, containerPorts.size());
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8090, (int) containerPorts.get(1).getContainerPort());
-		assertEquals(8090, (int) containerPorts.get(1).getHostPort());
-		assertEquals(8090, (int) container.getLivenessProbe().getHttpGet().getPort().getIntVal());
+		assertThat(containerPorts).hasSize(2);
+		assertThat(containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(1).getContainerPort()).isEqualTo(8090);
+		assertThat(containerPorts.get(1).getHostPort()).isEqualTo(8090);
+		assertThat(container.getLivenessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8090);
 	}
 
 	/**
@@ -541,17 +541,17 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
+		assertThat(containerPorts).isNotNull();
 
-		assertEquals("Only two container ports should be set", 2, containerPorts.size());
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8090, (int) containerPorts.get(1).getContainerPort());
-		assertEquals(8090, (int) containerPorts.get(1).getHostPort());
-		assertEquals(8090, (int) container.getReadinessProbe().getHttpGet().getPort().getIntVal());
+		assertThat(containerPorts).hasSize(2);
+		assertThat(containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(1).getContainerPort()).isEqualTo(8090);
+		assertThat(containerPorts.get(1).getHostPort()).isEqualTo(8090);
+		assertThat(container.getReadinessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8090);
 	}
 
 	@Test
@@ -571,17 +571,17 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
+		assertThat(containerPorts).isNotNull();
 
-		assertEquals("Only two container ports should be set", 2, containerPorts.size());
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8090, (int) containerPorts.get(1).getContainerPort());
-		assertEquals(8090, (int) containerPorts.get(1).getHostPort());
-		assertEquals(8090, (int) container.getReadinessProbe().getHttpGet().getPort().getIntVal());
+		assertThat(containerPorts).hasSize(2);
+		assertThat(containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(1).getContainerPort()).isEqualTo(8090);
+		assertThat(containerPorts.get(1).getHostPort()).isEqualTo(8090);
+		assertThat(container.getReadinessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8090);
 	}
 
 	/**
@@ -605,17 +605,17 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
+		assertThat(containerPorts).isNotNull();
 
-		assertEquals("Only two container ports should be set", 2, containerPorts.size());
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8090, (int) containerPorts.get(1).getContainerPort());
-		assertEquals(8090, (int) containerPorts.get(1).getHostPort());
-		assertEquals(8090, (int) container.getReadinessProbe().getHttpGet().getPort().getIntVal());
+		assertThat(containerPorts).hasSize(2);
+		assertThat(containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(1).getContainerPort()).isEqualTo(8090);
+		assertThat(containerPorts.get(1).getHostPort()).isEqualTo(8090);
+		assertThat(container.getReadinessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8090);
 	}
 
 	@Test
@@ -635,17 +635,17 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
+		assertThat(containerPorts).isNotNull();
 
-		assertEquals("Only two container ports should be set", 2, containerPorts.size());
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8090, (int) containerPorts.get(1).getContainerPort());
-		assertEquals(8090, (int) containerPorts.get(1).getHostPort());
-		assertEquals(8090, (int) container.getReadinessProbe().getHttpGet().getPort().getIntVal());
+		assertThat(containerPorts).hasSize(2);
+		assertThat(containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat(containerPorts.get(1).getContainerPort()).isEqualTo(8090);
+		assertThat(containerPorts.get(1).getHostPort()).isEqualTo(8090);
+		assertThat(container.getReadinessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8090);
 	}
 
 	@Test
@@ -666,14 +666,14 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(defaultPort);
 		Container container = defaultContainerFactory.create(containerConfiguration);
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 		List<ContainerPort> containerPorts = container.getPorts();
-		assertNotNull(containerPorts);
-		assertEquals("Only the default container port should set", 1, containerPorts.size());
-		assertEquals(8080, (int) containerPorts.get(0).getContainerPort());
-		assertEquals(8080, (int) containerPorts.get(0).getHostPort());
-		assertEquals(8080, (int) container.getLivenessProbe().getHttpGet().getPort().getIntVal());
-		assertEquals(8080, (int) container.getReadinessProbe().getHttpGet().getPort().getIntVal());
+		assertThat(containerPorts).isNotNull();
+		assertThat(containerPorts).as("Only the default container port should set").hasSize(1);
+		assertThat((int) containerPorts.get(0).getContainerPort()).isEqualTo(8080);
+		assertThat((int) containerPorts.get(0).getHostPort()).isEqualTo(8080);
+		assertThat((int) container.getLivenessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8080);
+		assertThat((int) container.getReadinessProbe().getHttpGet().getPort().getIntVal()).isEqualTo(8080);
 	}
 
 	@Test
@@ -695,13 +695,13 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
-		assertNotNull(container.getReadinessProbe().getHttpGet().getPath());
-		assertEquals(HttpProbeCreator.BOOT_2_READINESS_PROBE_PATH, container.getReadinessProbe().getHttpGet().getPath());
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isEqualTo(HttpProbeCreator.BOOT_2_READINESS_PROBE_PATH);
 
-		assertNotNull(container.getLivenessProbe().getHttpGet().getPath());
-		assertEquals(HttpProbeCreator.BOOT_2_LIVENESS_PROBE_PATH, container.getLivenessProbe().getHttpGet().getPath());
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isEqualTo(HttpProbeCreator.BOOT_2_LIVENESS_PROBE_PATH);
 	}
 
 	@Test
@@ -725,13 +725,13 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
-		assertNotNull(container.getReadinessProbe().getHttpGet().getPath());
-		assertEquals(HttpProbeCreator.BOOT_1_READINESS_PROBE_PATH, container.getReadinessProbe().getHttpGet().getPath());
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isEqualTo(HttpProbeCreator.BOOT_1_READINESS_PROBE_PATH);
 
-		assertNotNull(container.getLivenessProbe().getHttpGet().getPath());
-		assertEquals(HttpProbeCreator.BOOT_1_LIVENESS_PROBE_PATH, container.getLivenessProbe().getHttpGet().getPath());
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isEqualTo(HttpProbeCreator.BOOT_1_LIVENESS_PROBE_PATH);
 	}
 
 	/**
@@ -760,13 +760,13 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
-		assertNotNull(container.getReadinessProbe().getHttpGet().getPath());
-		assertEquals("/readiness", container.getReadinessProbe().getHttpGet().getPath());
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isEqualTo("/readiness");
 
-		assertNotNull(container.getLivenessProbe().getHttpGet().getPath());
-		assertEquals("/liveness", container.getLivenessProbe().getHttpGet().getPath());
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isEqualTo("/liveness");
 	}
 
 	@Test
@@ -791,13 +791,13 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
-		assertNotNull(container.getReadinessProbe().getHttpGet().getPath());
-		assertEquals("/readiness", container.getReadinessProbe().getHttpGet().getPath());
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isEqualTo("/readiness");
 
-		assertNotNull(container.getLivenessProbe().getHttpGet().getPath());
-		assertEquals("/liveness", container.getLivenessProbe().getHttpGet().getPath());
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isEqualTo("/liveness");
 	}
 
 	/**
@@ -824,13 +824,13 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
-		assertNotNull(container.getReadinessProbe().getHttpGet().getPath());
-		assertEquals("/readiness", container.getReadinessProbe().getHttpGet().getPath());
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isEqualTo("/readiness");
 
-		assertNotNull(container.getLivenessProbe().getHttpGet().getPath());
-		assertEquals("/liveness", container.getLivenessProbe().getHttpGet().getPath());
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isEqualTo("/liveness");
 	}
 
 	@Test
@@ -853,13 +853,13 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
-		assertNotNull(container.getReadinessProbe().getHttpGet().getPath());
-		assertEquals("/readiness", container.getReadinessProbe().getHttpGet().getPath());
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getReadinessProbe().getHttpGet().getPath()).isEqualTo("/readiness");
 
-		assertNotNull(container.getLivenessProbe().getHttpGet().getPath());
-		assertEquals("/liveness", container.getLivenessProbe().getHttpGet().getPath());
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isNotNull();
+		assertThat(container.getLivenessProbe().getHttpGet().getPath()).isEqualTo("/liveness");
 	}
 
 	@Test
@@ -884,15 +884,15 @@ public class DefaultContainerFactoryTests {
 				.get(HttpProbeCreator.PROBE_CREDENTIALS_SECRET_KEY_NAME);
 
 		HTTPHeader livenessProbeHeader = container.getLivenessProbe().getHttpGet().getHttpHeaders().get(0);
-		assertEquals(HttpProbeCreator.AUTHORIZATION_HEADER_NAME, livenessProbeHeader.getName());
-		assertEquals(ProbeAuthenticationType.Basic.name() + " " + credentials, livenessProbeHeader.getValue());
+		assertThat(livenessProbeHeader.getName()).isEqualTo(HttpProbeCreator.AUTHORIZATION_HEADER_NAME);
+		assertThat(livenessProbeHeader.getValue()).isEqualTo(ProbeAuthenticationType.Basic.name() + " " + credentials);
 
 		HTTPHeader readinessProbeHeader = container.getReadinessProbe().getHttpGet().getHttpHeaders().get(0);
-		assertEquals(HttpProbeCreator.AUTHORIZATION_HEADER_NAME, readinessProbeHeader.getName());
-		assertEquals(ProbeAuthenticationType.Basic.name() + " " + credentials, readinessProbeHeader.getValue());
+		assertThat(readinessProbeHeader.getName()).isEqualTo(HttpProbeCreator.AUTHORIZATION_HEADER_NAME);
+		assertThat(readinessProbeHeader.getValue()).isEqualTo(ProbeAuthenticationType.Basic.name() + " " + credentials);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testHttpProbeCredentialsInvalidSecret() {
 		Secret secret = randomSecret();
 		secret.setData(Collections.singletonMap("unexpectedkey", "dXNlcjpwYXNz"));
@@ -910,9 +910,9 @@ public class DefaultContainerFactoryTests {
 				.withProbeCredentialsSecret(secret);
 
 		ContainerFactory containerFactory = new DefaultContainerFactory(new KubernetesDeployerProperties());
-		containerFactory.create(containerConfiguration);
-
-		fail();
+		assertThatThrownBy(() -> {
+			containerFactory.create(containerConfiguration);
+		}).isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test
@@ -926,10 +926,8 @@ public class DefaultContainerFactoryTests {
 		ContainerFactory containerFactory = new DefaultContainerFactory(new KubernetesDeployerProperties());
 		Container container = containerFactory.create(containerConfiguration);
 
-		assertTrue("Liveness probe should not contain any HTTP headers",
-				container.getLivenessProbe().getHttpGet().getHttpHeaders().isEmpty());
-		assertTrue("Readiness probe should not contain any HTTP headers",
-				container.getReadinessProbe().getHttpGet().getHttpHeaders().isEmpty());
+		assertThat(container.getLivenessProbe().getHttpGet().getHttpHeaders()).isEmpty();
+		assertThat(container.getReadinessProbe().getHttpGet().getHttpHeaders()).isEmpty();
 	}
 
 	@Test
@@ -954,7 +952,7 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		assertThat(container.getPorts())
 				.contains(new ContainerPortBuilder().withHostPort(5050).withContainerPort(5050).build());
@@ -964,22 +962,22 @@ public class DefaultContainerFactoryTests {
 		Probe livenessProbe = container.getLivenessProbe();
 		Probe readinessProbe = container.getReadinessProbe();
 
-		assertNotNull("LivenessProbe should not be null", livenessProbe);
-		assertNotNull("ReadinessProbe should not be null", readinessProbe);
+		assertThat(livenessProbe).isNotNull();
+		assertThat(readinessProbe).isNotNull();
 
 		Integer livenessTcpProbePort = livenessProbe.getTcpSocket().getPort().getIntVal();
-		assertNotNull("Liveness TCP probe port should not be null", livenessTcpProbePort);
-		assertEquals("Invalid liveness TCP probe port", 9090, livenessTcpProbePort.intValue());
+		assertThat(livenessTcpProbePort).isNotNull();
+		assertThat(livenessTcpProbePort.intValue()).isEqualTo(9090);
 
 		Integer readinessTcpProbePort = readinessProbe.getTcpSocket().getPort().getIntVal();
-		assertNotNull("Readiness TCP probe port should not be null", readinessTcpProbePort);
-		assertEquals("Invalid readiness TCP probe port", 5050, readinessTcpProbePort.intValue());
+		assertThat(readinessTcpProbePort).isNotNull();
+		assertThat(readinessTcpProbePort.intValue()).isEqualTo(5050);
 
-		assertNotNull("Liveness TCP probe period seconds should not be null", livenessProbe.getPeriodSeconds());
-		assertNotNull("Readiness TCP probe period seconds should not be null", readinessProbe.getPeriodSeconds());
+		assertThat(livenessProbe.getPeriodSeconds()).isNotNull();
+		assertThat(readinessProbe.getPeriodSeconds()).isNotNull();
 
-		assertNotNull("Liveness TCP probe initial delay seconds should not be null", livenessProbe.getInitialDelaySeconds());
-		assertNotNull("Readiness TCP probe initial delay seconds should not be null", readinessProbe.getInitialDelaySeconds());
+		assertThat(livenessProbe.getInitialDelaySeconds()).isNotNull();
+		assertThat(readinessProbe.getInitialDelaySeconds()).isNotNull();
 	}
 
 	@Test
@@ -1001,12 +999,10 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 
-		try {
+		assertThatThrownBy(() -> {
 			defaultContainerFactory.create(containerConfiguration);
-		} catch (IllegalArgumentException e) {
-			assertTrue("Expected livenessTcpProbePort to be set", e.getMessage()
-					.contains("The livenessTcpProbePort property must be set"));
-		}
+		}).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("The livenessTcpProbePort property must be set");
 	}
 
 	@Test
@@ -1028,12 +1024,10 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 
-		try {
+		assertThatThrownBy(() -> {
 			defaultContainerFactory.create(containerConfiguration);
-		} catch (IllegalArgumentException e) {
-			assertTrue("A readinessTcpProbePort property must be set.", e.getMessage()
-					.contains("A readinessTcpProbePort property must be set."));
-		}
+		}).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("A readinessTcpProbePort property must be set");
 	}
 
 	@Test
@@ -1056,12 +1050,10 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 
-		try {
+		assertThatThrownBy(() -> {
 			defaultContainerFactory.create(containerConfiguration);
-		} catch (Exception e) {
-			assertTrue("ReadinessTcpPortProbe must contain all digits",
-					e.getMessage().contains("ReadinessTcpProbePort must contain all digits"));
-		}
+		}).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("ReadinessTcpProbePort must contain all digits");
 	}
 
 	@Test
@@ -1084,12 +1076,10 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 
-		try {
+		assertThatThrownBy(() -> {
 			defaultContainerFactory.create(containerConfiguration);
-		} catch (Exception e) {
-			assertTrue("LivenessTcpPortProbe must contain all digits",
-					e.getMessage().contains("LivenessTcpProbePort must contain all digits"));
-		}
+		}).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("LivenessTcpProbePort must contain all digits");
 	}
 
 	@Test
@@ -1117,7 +1107,7 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		assertThat(container.getPorts())
 				.contains(new ContainerPortBuilder().withHostPort(5050).withContainerPort(5050).build());
@@ -1127,32 +1117,32 @@ public class DefaultContainerFactoryTests {
 		Probe livenessProbe = container.getLivenessProbe();
 		Probe readinessProbe = container.getReadinessProbe();
 
-		assertNotNull("LivenessProbe should not be null", livenessProbe);
-		assertNotNull("ReadinessProbe should not be null", readinessProbe);
+		assertThat(livenessProbe).isNotNull();
+		assertThat(readinessProbe).isNotNull();
 
 		Integer livenessTcpProbePort = livenessProbe.getTcpSocket().getPort().getIntVal();
-		assertNotNull("Liveness TCP probe port should not be null", livenessTcpProbePort);
-		assertEquals("Invalid liveness TCP probe port", 9090, livenessTcpProbePort.intValue());
+		assertThat(livenessTcpProbePort).isNotNull();
+		assertThat(livenessTcpProbePort.intValue()).isEqualTo(9090);
 
 		Integer readinessTcpProbePort = readinessProbe.getTcpSocket().getPort().getIntVal();
-		assertNotNull("Readiness TCP probe port should not be null", readinessTcpProbePort);
-		assertEquals("Invalid readiness TCP probe port", 5050, readinessTcpProbePort.intValue());
+		assertThat(readinessTcpProbePort).isNotNull();
+		assertThat(readinessTcpProbePort.intValue()).isEqualTo(5050);
 
 		Integer livenessProbePeriodSeconds = livenessProbe.getPeriodSeconds();
-		assertNotNull("Liveness TCP probe period seconds should not be null", livenessProbePeriodSeconds);
-		assertEquals("Invalid livesness TCP probe period seconds", 4, livenessProbePeriodSeconds.intValue());
+		assertThat(livenessProbePeriodSeconds).isNotNull();
+		assertThat(livenessProbePeriodSeconds.intValue()).isEqualTo(4);
 
 		Integer readinessProbePeriodSeconds = readinessProbe.getPeriodSeconds();
-		assertNotNull("Readiness TCP probe period seconds should not be null", readinessProbePeriodSeconds);
-		assertEquals("Invalid readiness TCP probe period seconds", 2, readinessProbePeriodSeconds.intValue());
+		assertThat(readinessProbePeriodSeconds).isNotNull();
+		assertThat(readinessProbePeriodSeconds.intValue()).isEqualTo(2);
 
 		Integer livenessProbeInitialDelaySeconds = livenessProbe.getInitialDelaySeconds();
-		assertNotNull("Liveness TCP probe initial delay seconds should not be null", livenessProbeInitialDelaySeconds);
-		assertEquals("Invalid liveness TCP probe initial delay seconds", 3, livenessProbeInitialDelaySeconds.intValue());
+		assertThat(livenessProbeInitialDelaySeconds).isNotNull();
+		assertThat(livenessProbeInitialDelaySeconds.intValue()).isEqualTo(3);
 
 		Integer readinessProbeInitialDelaySeconds = readinessProbe.getInitialDelaySeconds();
-		assertNotNull("Readiness TCP probe initial delay seconds should not be null", readinessProbeInitialDelaySeconds);
-		assertEquals("Invalid readiness TCP probe initial delay seconds", 1, readinessProbeInitialDelaySeconds.intValue());
+		assertThat(readinessProbeInitialDelaySeconds).isNotNull();
+		assertThat(readinessProbeInitialDelaySeconds.intValue()).isEqualTo(1);
 	}
 
 	@Test
@@ -1189,7 +1179,7 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		assertThat(container.getPorts())
 				.contains(new ContainerPortBuilder().withHostPort(5050).withContainerPort(5050).build());
@@ -1199,32 +1189,32 @@ public class DefaultContainerFactoryTests {
 		Probe livenessProbe = container.getLivenessProbe();
 		Probe readinessProbe = container.getReadinessProbe();
 
-		assertNotNull("LivenessProbe should not be null", livenessProbe);
-		assertNotNull("ReadinessProbe should not be null", readinessProbe);
+		assertThat(livenessProbe).isNotNull();
+		assertThat(readinessProbe).isNotNull();
 
 		Integer livenessTcpProbePort = livenessProbe.getTcpSocket().getPort().getIntVal();
-		assertNotNull("Liveness TCP probe port should not be null", livenessTcpProbePort);
-		assertEquals("Invalid liveness TCP probe port", 9090, livenessTcpProbePort.intValue());
+		assertThat(livenessTcpProbePort).isNotNull();
+		assertThat(livenessTcpProbePort.intValue()).isEqualTo(9090);
 
 		Integer readinessTcpProbePort = readinessProbe.getTcpSocket().getPort().getIntVal();
-		assertNotNull("Readiness TCP probe port should not be null", readinessTcpProbePort);
-		assertEquals("Invalid readiness TCP probe port", 5050, readinessTcpProbePort.intValue());
+		assertThat(readinessTcpProbePort).isNotNull();
+		assertThat(readinessTcpProbePort.intValue()).isEqualTo(5050);
 
 		Integer livenessProbePeriodSeconds = livenessProbe.getPeriodSeconds();
-		assertNotNull("Liveness TCP probe period seconds should not be null", livenessProbePeriodSeconds);
-		assertEquals("Invalid livesness TCP probe period seconds", 13, livenessProbePeriodSeconds.intValue());
+		assertThat(livenessProbePeriodSeconds).isNotNull();
+		assertThat(livenessProbePeriodSeconds.intValue()).isEqualTo(13);
 
 		Integer readinessProbePeriodSeconds = readinessProbe.getPeriodSeconds();
-		assertNotNull("Readiness TCP probe period seconds should not be null", readinessProbePeriodSeconds);
-		assertEquals("Invalid readiness TCP probe period seconds", 11, readinessProbePeriodSeconds.intValue());
+		assertThat(readinessProbePeriodSeconds).isNotNull();
+		assertThat(readinessProbePeriodSeconds.intValue()).isEqualTo(11);
 
 		Integer livenessProbeInitialDelaySeconds = livenessProbe.getInitialDelaySeconds();
-		assertNotNull("Liveness TCP probe initial delay seconds should not be null", livenessProbeInitialDelaySeconds);
-		assertEquals("Invalid liveness TCP probe initial delay seconds", 14, livenessProbeInitialDelaySeconds.intValue());
+		assertThat(livenessProbeInitialDelaySeconds).isNotNull();
+		assertThat(livenessProbeInitialDelaySeconds.intValue()).isEqualTo(14);
 
 		Integer readinessProbeInitialDelaySeconds = readinessProbe.getInitialDelaySeconds();
-		assertNotNull("Readiness TCP probe initial delay seconds should not be null", readinessProbeInitialDelaySeconds);
-		assertEquals("Invalid readiness TCP probe initial delay seconds", 12, readinessProbeInitialDelaySeconds.intValue());
+		assertThat(readinessProbeInitialDelaySeconds).isNotNull();
+		assertThat(readinessProbeInitialDelaySeconds.intValue()).isEqualTo(12);
 	}
 
 	@Test
@@ -1249,27 +1239,25 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		Probe livenessProbe = container.getLivenessProbe();
 		Probe readinessProbe = container.getReadinessProbe();
 
-		assertNotNull("LivenessProbe should not be null", livenessProbe);
-		assertNotNull("ReadinessProbe should not be null", readinessProbe);
+		assertThat(livenessProbe).isNotNull();
+		assertThat(readinessProbe).isNotNull();
 
 		List<String> livenessCommandProbeCommand = livenessProbe.getExec().getCommand();
-		assertFalse("Liveness command probe command should not be empty", livenessCommandProbeCommand.isEmpty());
-		assertEquals("Invalid liveness command probe command", "ls /dev", String.join(" ", livenessCommandProbeCommand));
+		assertThat(livenessCommandProbeCommand).containsExactly("ls", "/dev");
 
 		List<String> readinessCommandProbeCommand = readinessProbe.getExec().getCommand();
-		assertFalse("Readiness command probe command should not be empty", readinessCommandProbeCommand.isEmpty());
-		assertEquals("Invalid readiness command probe command", "ls /", String.join(" ", readinessCommandProbeCommand));
+		assertThat(readinessCommandProbeCommand).containsExactly("ls", "/");
 
-		assertNotNull("Liveness command probe period seconds should not be null", livenessProbe.getPeriodSeconds());
-		assertNotNull("Readiness command probe period seconds should not be null", readinessProbe.getPeriodSeconds());
+		assertThat(livenessProbe.getPeriodSeconds()).isNotNull();
+		assertThat(readinessProbe.getPeriodSeconds()).isNotNull();
 
-		assertNotNull("Liveness command probe initial delay seconds should not be null", livenessProbe.getInitialDelaySeconds());
-		assertNotNull("Readiness command probe initial delay seconds should not be null", readinessProbe.getInitialDelaySeconds());
+		assertThat(livenessProbe.getInitialDelaySeconds()).isNotNull();
+		assertThat(readinessProbe.getInitialDelaySeconds()).isNotNull();
 	}
 
 	@Test
@@ -1290,12 +1278,10 @@ public class DefaultContainerFactoryTests {
 				.withHostNetwork(true)
 				.withExternalPort(8080);
 
-		try {
+		assertThatThrownBy(() -> {
 			defaultContainerFactory.create(containerConfiguration);
-		} catch (IllegalArgumentException e) {
-			assertTrue("The readinessCommandProbeCommand property must be set.", e.getMessage()
-					.contains("The readinessCommandProbeCommand property must be set."));
-		}
+		}).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("The readinessCommandProbeCommand property must be set");
 	}
 
 	@Test
@@ -1323,37 +1309,37 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		Probe livenessProbe = container.getLivenessProbe();
 		Probe readinessProbe = container.getReadinessProbe();
 
-		assertNotNull("LivenessProbe should not be null", livenessProbe);
-		assertNotNull("ReadinessProbe should not be null", readinessProbe);
+		assertThat(livenessProbe).isNotNull();
+		assertThat(readinessProbe).isNotNull();
 
 		String livenessTcpProbeCommand = String.join(" ", livenessProbe.getExec().getCommand());
-		assertNotNull("Liveness command probe command should not be null", livenessTcpProbeCommand);
-		assertEquals("Invalid liveness command probe command", "ls /dev", livenessTcpProbeCommand);
+		assertThat(livenessTcpProbeCommand).isNotNull();
+		assertThat(livenessTcpProbeCommand).isEqualTo("ls /dev");
 
 		String readinessTcpProbeCommand = String.join(" ", readinessProbe.getExec().getCommand());
-		assertNotNull("Readiness command probe command should not be null", readinessTcpProbeCommand);
-		assertEquals("Invalid readiness command probe command", "ls /", readinessTcpProbeCommand);
+		assertThat(readinessTcpProbeCommand).isNotNull();
+		assertThat(readinessTcpProbeCommand).isEqualTo("ls /");
 
 		Integer livenessProbePeriodSeconds = livenessProbe.getPeriodSeconds();
-		assertNotNull("Liveness command probe period seconds should not be null", livenessProbePeriodSeconds);
-		assertEquals("Invalid livesness command probe period seconds", 4, livenessProbePeriodSeconds.intValue());
+		assertThat(livenessProbePeriodSeconds).isNotNull();
+		assertThat(livenessProbePeriodSeconds.intValue()).isEqualTo(4);
 
 		Integer readinessProbePeriodSeconds = readinessProbe.getPeriodSeconds();
-		assertNotNull("Readiness command probe period seconds should not be null", readinessProbePeriodSeconds);
-		assertEquals("Invalid readiness command probe period seconds", 2, readinessProbePeriodSeconds.intValue());
+		assertThat(readinessProbePeriodSeconds).isNotNull();
+		assertThat(readinessProbePeriodSeconds.intValue()).isEqualTo(2);
 
 		Integer livenessProbeInitialDelaySeconds = livenessProbe.getInitialDelaySeconds();
-		assertNotNull("Liveness command probe initial delay seconds should not be null", livenessProbeInitialDelaySeconds);
-		assertEquals("Invalid liveness command probe initial delay seconds", 3, livenessProbeInitialDelaySeconds.intValue());
+		assertThat(livenessProbeInitialDelaySeconds).isNotNull();
+		assertThat(livenessProbeInitialDelaySeconds.intValue()).isEqualTo(3);
 
 		Integer readinessProbeInitialDelaySeconds = readinessProbe.getInitialDelaySeconds();
-		assertNotNull("Readiness command probe initial delay seconds should not be null", readinessProbeInitialDelaySeconds);
-		assertEquals("Invalid readiness command probe initial delay seconds", 1, readinessProbeInitialDelaySeconds.intValue());
+		assertThat(readinessProbeInitialDelaySeconds).isNotNull();
+		assertThat(readinessProbeInitialDelaySeconds.intValue()).isEqualTo(1);
 	}
 
 	@Test
@@ -1390,37 +1376,37 @@ public class DefaultContainerFactoryTests {
 
 		Container container = defaultContainerFactory.create(containerConfiguration);
 
-		assertNotNull(container);
+		assertThat(container).isNotNull();
 
 		Probe livenessProbe = container.getLivenessProbe();
 		Probe readinessProbe = container.getReadinessProbe();
 
-		assertNotNull("LivenessProbe should not be null", livenessProbe);
-		assertNotNull("ReadinessProbe should not be null", readinessProbe);
+		assertThat(livenessProbe).isNotNull();
+		assertThat(readinessProbe).isNotNull();
 
 		String livenessTcpProbeCommand = String.join(" ", livenessProbe.getExec().getCommand());
-		assertNotNull("Liveness command probe command should not be null", livenessTcpProbeCommand);
-		assertEquals("Invalid liveness command probe command", "ls /dev", livenessTcpProbeCommand);
+		assertThat(livenessTcpProbeCommand).isNotNull();
+		assertThat(livenessTcpProbeCommand).isEqualTo("ls /dev");
 
 		String readinessTcpProbeCommand = String.join(" ", readinessProbe.getExec().getCommand());
-		assertNotNull("Readiness command probe command should not be null", readinessTcpProbeCommand);
-		assertEquals("Invalid readiness command probe command", "ls /", readinessTcpProbeCommand);
+		assertThat(readinessTcpProbeCommand).isNotNull();
+		assertThat(readinessTcpProbeCommand).isEqualTo("ls /");
 
 		Integer livenessProbePeriodSeconds = livenessProbe.getPeriodSeconds();
-		assertNotNull("Liveness command probe period seconds should not be null", livenessProbePeriodSeconds);
-		assertEquals("Invalid livesness command probe period seconds", 13, livenessProbePeriodSeconds.intValue());
+		assertThat(livenessProbePeriodSeconds).isNotNull();
+		assertThat(livenessProbePeriodSeconds.intValue()).isEqualTo(13);
 
 		Integer readinessProbePeriodSeconds = readinessProbe.getPeriodSeconds();
-		assertNotNull("Readiness command probe period seconds should not be null", readinessProbePeriodSeconds);
-		assertEquals("Invalid readiness command probe period seconds", 11, readinessProbePeriodSeconds.intValue());
+		assertThat(readinessProbePeriodSeconds).isNotNull();
+		assertThat(readinessProbePeriodSeconds.intValue()).isEqualTo(11);
 
 		Integer livenessProbeInitialDelaySeconds = livenessProbe.getInitialDelaySeconds();
-		assertNotNull("Liveness command probe initial delay seconds should not be null", livenessProbeInitialDelaySeconds);
-		assertEquals("Invalid liveness command probe initial delay seconds", 14, livenessProbeInitialDelaySeconds.intValue());
+		assertThat(livenessProbeInitialDelaySeconds).isNotNull();
+		assertThat(livenessProbeInitialDelaySeconds.intValue()).isEqualTo(14);
 
 		Integer readinessProbeInitialDelaySeconds = readinessProbe.getInitialDelaySeconds();
-		assertNotNull("Readiness command probe initial delay seconds should not be null", readinessProbeInitialDelaySeconds);
-		assertEquals("Invalid readiness command probe initial delay seconds", 12, readinessProbeInitialDelaySeconds.intValue());
+		assertThat(readinessProbeInitialDelaySeconds).isNotNull();
+		assertThat(readinessProbeInitialDelaySeconds.intValue()).isEqualTo(12);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/EntryPointStyleTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/EntryPointStyleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.cloud.deployer.spi.kubernetes;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link EntryPointStyle}
@@ -25,24 +25,25 @@ import static org.junit.Assert.assertEquals;
  * @author Chris Schaefer
  */
 public class EntryPointStyleTests {
+
 	@Test
 	public void testInvalidEntryPointStyleDefaulting() {
 		EntryPointStyle entryPointStyle = EntryPointStyle
 				.relaxedValueOf("unknown");
-		assertEquals(EntryPointStyle.exec, entryPointStyle);
+		assertThat(entryPointStyle).isEqualTo(EntryPointStyle.exec);
 	}
 
 	@Test
 	public void testMatchEntryPointStyle() {
 		EntryPointStyle entryPointStyle = EntryPointStyle
 				.relaxedValueOf("shell");
-		assertEquals(EntryPointStyle.shell, entryPointStyle);
+		assertThat(entryPointStyle).isEqualTo(EntryPointStyle.shell);
 	}
 
 	@Test
 	public void testMixedCaseEntryPointStyle() {
 		EntryPointStyle entryPointStyle = EntryPointStyle
 				.relaxedValueOf("bOOt");
-		assertEquals(EntryPointStyle.boot, entryPointStyle);
+		assertThat(entryPointStyle).isEqualTo(EntryPointStyle.boot);
 	}
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/ImagePullPolicyTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/ImagePullPolicyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,9 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link ImagePullPolicy}.
@@ -32,18 +30,18 @@ public class ImagePullPolicyTests {
 	@Test
 	public void relaxedValueOf_ignoresCase() throws Exception {
 		ImagePullPolicy pullPolicy = ImagePullPolicy.relaxedValueOf("aLWays");
-		assertThat(pullPolicy, is(ImagePullPolicy.Always));
+		assertThat(pullPolicy).isEqualTo(ImagePullPolicy.Always);
 	}
 
 	@Test
 	public void relaxedValueOf_parsesValueWithDashesInsteadOfCamelCase() throws Exception {
 		ImagePullPolicy pullPolicy = ImagePullPolicy.relaxedValueOf("if-not-present");
-		assertThat(pullPolicy, is(ImagePullPolicy.IfNotPresent));
+		assertThat(pullPolicy).isEqualTo(ImagePullPolicy.IfNotPresent);
 	}
 
 	@Test
 	public void relaxedValueOf_returnsNullIfValueNotParseable() throws Exception {
 		ImagePullPolicy pullPolicy = ImagePullPolicy.relaxedValueOf("not-a-real-policy");
-		assertThat(pullPolicy, is(nullValue()));
+		assertThat(pullPolicy).isNull();
 	}
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -44,7 +44,7 @@ import io.fabric8.kubernetes.api.model.SecretKeySelector;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.WeightedPodAffinityTerm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.boot.context.properties.bind.Bindable;
@@ -57,11 +57,8 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for {@link KubernetesAppDeployer}
@@ -261,7 +258,7 @@ public class KubernetesAppDeployerTests {
 		assertThat(podSpec.getImagePullSecrets().size()).isEqualTo(1);
 		assertThat(podSpec.getImagePullSecrets().get(0).getName()).isEqualTo("regcred");
 	}
-	
+
 	@Test
 	public void deployWithImagePullSecretsDeploymentProperty() {
 		AppDefinition definition = new AppDefinition("app-test", null);
@@ -308,7 +305,7 @@ public class KubernetesAppDeployerTests {
 		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
-		assertNotNull(podSpec.getServiceAccountName());
+		assertThat(podSpec.getServiceAccountName()).isNotNull();
 		assertThat(podSpec.getServiceAccountName().equals("myserviceaccount"));
 	}
 
@@ -324,7 +321,7 @@ public class KubernetesAppDeployerTests {
 		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
-		assertNotNull(podSpec.getServiceAccountName());
+		assertThat(podSpec.getServiceAccountName()).isNotNull();
 		assertThat(podSpec.getServiceAccountName().equals("myserviceaccount"));
 	}
 
@@ -343,7 +340,7 @@ public class KubernetesAppDeployerTests {
 		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
-		assertNotNull(podSpec.getServiceAccountName());
+		assertThat(podSpec.getServiceAccountName()).isNotNull();
 		assertThat(podSpec.getServiceAccountName().equals("overridesan"));
 	}
 
@@ -373,7 +370,7 @@ public class KubernetesAppDeployerTests {
 		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
-		assertNotNull(podSpec.getTolerations());
+		assertThat(podSpec.getTolerations()).isNotNull();
 		assertThat(podSpec.getTolerations().size() == 2);
 		assertThat(podSpec.getTolerations().contains(new Toleration("NoSchedule", "test", "Equal", 5L, "true")));
 		assertThat(podSpec.getTolerations().contains(new Toleration("NoSchedule", "test2", "Equal", 5L, "false")));
@@ -403,7 +400,7 @@ public class KubernetesAppDeployerTests {
 		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
-		assertNotNull(podSpec.getTolerations());
+		assertThat(podSpec.getTolerations()).isNotNull();
 		assertThat(podSpec.getTolerations().size() == 2);
 		assertThat(podSpec.getTolerations().contains(new Toleration("NoSchedule", "test", "Equal", 5L, "true")));
 		assertThat(podSpec.getTolerations().contains(new Toleration("NoSchedule", "test2", "Equal", 5L, "false")));
@@ -432,7 +429,7 @@ public class KubernetesAppDeployerTests {
 		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
-		assertNotNull(podSpec.getTolerations());
+		assertThat(podSpec.getTolerations()).isNotNull();
 		assertThat(podSpec.getTolerations().size() == 1);
 		assertThat(podSpec.getTolerations().contains(new Toleration("NoSchedule", "test2", "Equal", 5L, "false")));
 	}
@@ -466,22 +463,25 @@ public class KubernetesAppDeployerTests {
 		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
-		assertNotNull(podSpec.getTolerations());
+		assertThat(podSpec.getTolerations()).isNotNull();
 		assertThat(podSpec.getTolerations().size() == 1);
 		assertThat(podSpec.getTolerations().contains(new Toleration("NoSchedule", "test2", "Equal", 5L, "true")));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidDeploymentLabelDelimiter() {
 		Map<String, String> props = Collections.singletonMap("spring.cloud.deployer.kubernetes.deploymentLabels",
 				"label1|value1");
 
 		AppDefinition definition = new AppDefinition("app-test", null);
 		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-		this.deploymentPropertiesResolver.getDeploymentLabels(appDeploymentRequest.getDeploymentProperties());
+
+		assertThatThrownBy(() -> {
+			this.deploymentPropertiesResolver.getDeploymentLabels(appDeploymentRequest.getDeploymentProperties());
+		}).isInstanceOf(IllegalArgumentException.class);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidMultipleDeploymentLabelDelimiter() {
 		Map<String, String> props = Collections.singletonMap("spring.cloud.deployer.kubernetes.deploymentLabels",
 				"label1:value1 label2:value2");
@@ -489,7 +489,9 @@ public class KubernetesAppDeployerTests {
 		AppDefinition definition = new AppDefinition("app-test", null);
 		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
 
-		this.deploymentPropertiesResolver.getDeploymentLabels(appDeploymentRequest.getDeploymentProperties());
+		assertThatThrownBy(() -> {
+			this.deploymentPropertiesResolver.getDeploymentLabels(appDeploymentRequest.getDeploymentProperties());
+		}).isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test
@@ -502,12 +504,12 @@ public class KubernetesAppDeployerTests {
 
 		Map<String, String> deploymentLabels = this.deploymentPropertiesResolver.getDeploymentLabels(appDeploymentRequest.getDeploymentProperties());
 
-		assertTrue("Deployment labels should not be empty", !deploymentLabels.isEmpty());
-		assertEquals("Invalid number of labels", 2, deploymentLabels.size());
-		assertTrue("Expected label 'label1' not found", deploymentLabels.containsKey("label1"));
-		assertEquals("Invalid value for 'label1'", "value1", deploymentLabels.get("label1"));
-		assertTrue("Expected label 'label2' not found", deploymentLabels.containsKey("label2"));
-		assertEquals("Invalid value for 'label2'", "value2", deploymentLabels.get("label2"));
+		assertThat(deploymentLabels).isNotEmpty();
+		assertThat(deploymentLabels.size()).as("Invalid number of labels").isEqualTo(2);
+		assertThat(deploymentLabels).containsKey("label1");
+		assertThat(deploymentLabels.get("label1")).as("Invalid value for 'label1'").isEqualTo("value1");
+		assertThat(deploymentLabels).containsKey("label2");
+		assertThat(deploymentLabels.get("label2")).as("Invalid value for 'label2'").isEqualTo("value2");
 	}
 
 	@Test
@@ -524,13 +526,13 @@ public class KubernetesAppDeployerTests {
 
 		List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
 
-		assertEquals("Invalid number of env vars", 2, envVars.size());
+		assertThat(envVars.size()).as("Invalid number of env vars").isEqualTo(2);
 
 		EnvVar secretKeyRefEnvVar = envVars.get(0);
-		assertEquals("Unexpected env var name", "SECRET_PASSWORD", secretKeyRefEnvVar.getName());
+		assertThat(secretKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("SECRET_PASSWORD");
 		SecretKeySelector secretKeySelector = secretKeyRefEnvVar.getValueFrom().getSecretKeyRef();
-		assertEquals("Unexpected secret name", "mySecret", secretKeySelector.getName());
-		assertEquals("Unexpected secret data key", "password", secretKeySelector.getKey());
+		assertThat(secretKeySelector.getName()).as("Unexpected secret name").isEqualTo("mySecret");
+		assertThat(secretKeySelector.getKey()).as("Unexpected secret data key").isEqualTo("password");
 	}
 
 	@Test
@@ -548,19 +550,19 @@ public class KubernetesAppDeployerTests {
 
 		List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
 
-		assertEquals("Invalid number of env vars", 3, envVars.size());
+		assertThat(envVars.size()).as("Invalid number of env vars").isEqualTo(3);
 
 		EnvVar secretKeyRefEnvVar = envVars.get(0);
-		assertEquals("Unexpected env var name", "SECRET_PASSWORD", secretKeyRefEnvVar.getName());
+		assertThat(secretKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("SECRET_PASSWORD");
 		SecretKeySelector secretKeySelector = secretKeyRefEnvVar.getValueFrom().getSecretKeyRef();
-		assertEquals("Unexpected secret name", "mySecret", secretKeySelector.getName());
-		assertEquals("Unexpected secret data key", "password", secretKeySelector.getKey());
+		assertThat(secretKeySelector.getName()).as("Unexpected secret name").isEqualTo("mySecret");
+		assertThat(secretKeySelector.getKey()).as("Unexpected secret data key").isEqualTo("password");
 
 		secretKeyRefEnvVar = envVars.get(1);
-		assertEquals("Unexpected env var name", "SECRET_USERNAME", secretKeyRefEnvVar.getName());
+		assertThat(secretKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("SECRET_USERNAME");
 		secretKeySelector = secretKeyRefEnvVar.getValueFrom().getSecretKeyRef();
-		assertEquals("Unexpected secret name", "mySecret2", secretKeySelector.getName());
-		assertEquals("Unexpected secret data key", "username", secretKeySelector.getKey());
+		assertThat(secretKeySelector.getName()).as("Unexpected secret name").isEqualTo("mySecret2");
+		assertThat(secretKeySelector.getKey()).as("Unexpected secret data key").isEqualTo("username");
 	}
 
 	@Test
@@ -580,13 +582,13 @@ public class KubernetesAppDeployerTests {
 
 		List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
 
-		assertEquals("Invalid number of env vars", 2, envVars.size());
+		assertThat(envVars.size()).as("Invalid number of env vars").isEqualTo(2);
 
 		EnvVar secretKeyRefEnvVar = envVars.get(0);
-		assertEquals("Unexpected env var name", "SECRET_PASSWORD_GLOBAL", secretKeyRefEnvVar.getName());
+		assertThat(secretKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("SECRET_PASSWORD_GLOBAL");
 		SecretKeySelector secretKeySelector = secretKeyRefEnvVar.getValueFrom().getSecretKeyRef();
-		assertEquals("Unexpected secret name", "mySecretGlobal", secretKeySelector.getName());
-		assertEquals("Unexpected secret data key", "passwordGlobal", secretKeySelector.getKey());
+		assertThat(secretKeySelector.getName()).as("Unexpected secret name").isEqualTo("mySecretGlobal");
+		assertThat(secretKeySelector.getKey()).as("Unexpected secret data key").isEqualTo("passwordGlobal");
 	}
 
 	@Test
@@ -622,28 +624,28 @@ public class KubernetesAppDeployerTests {
 
 		List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
 
-		assertEquals("Invalid number of env vars", 4, envVars.size());
+		assertThat(envVars.size()).as("Invalid number of env vars").isEqualTo(4);
 
 		// deploy prop overrides global
 		EnvVar secretKeyRefEnvVar = envVars.get(0);
-		assertEquals("Unexpected env var name", "SECRET_PASSWORD_GLOBAL", secretKeyRefEnvVar.getName());
+		assertThat(secretKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("SECRET_PASSWORD_GLOBAL");
 		SecretKeySelector secretKeySelector = secretKeyRefEnvVar.getValueFrom().getSecretKeyRef();
-		assertEquals("Unexpected secret name", "mySecret", secretKeySelector.getName());
-		assertEquals("Unexpected secret data key", "password", secretKeySelector.getKey());
+		assertThat(secretKeySelector.getName()).as("Unexpected secret name").isEqualTo("mySecret");
+		assertThat(secretKeySelector.getKey()).as("Unexpected secret data key").isEqualTo("password");
 
 		// unique deploy prop
 		secretKeyRefEnvVar = envVars.get(1);
-		assertEquals("Unexpected env var name", "SECRET_USERNAME", secretKeyRefEnvVar.getName());
+		assertThat(secretKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("SECRET_USERNAME");
 		secretKeySelector = secretKeyRefEnvVar.getValueFrom().getSecretKeyRef();
-		assertEquals("Unexpected secret name", "mySecret2", secretKeySelector.getName());
-		assertEquals("Unexpected secret data key", "username", secretKeySelector.getKey());
+		assertThat(secretKeySelector.getName()).as("Unexpected secret name").isEqualTo("mySecret2");
+		assertThat(secretKeySelector.getKey()).as("Unexpected secret data key").isEqualTo("username");
 
 		// unique, non-overridden global prop
 		secretKeyRefEnvVar = envVars.get(2);
-		assertEquals("Unexpected env var name", "SECRET_USERNAME_GLOBAL", secretKeyRefEnvVar.getName());
+		assertThat(secretKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("SECRET_USERNAME_GLOBAL");
 		secretKeySelector = secretKeyRefEnvVar.getValueFrom().getSecretKeyRef();
-		assertEquals("Unexpected secret name", "mySecretGlobal", secretKeySelector.getName());
-		assertEquals("Unexpected secret data key", "usernameGlobal", secretKeySelector.getKey());
+		assertThat(secretKeySelector.getName()).as("Unexpected secret name").isEqualTo("mySecretGlobal");
+		assertThat(secretKeySelector.getKey()).as("Unexpected secret data key").isEqualTo("usernameGlobal");
 	}
 
 	@Test
@@ -656,13 +658,13 @@ public class KubernetesAppDeployerTests {
 
 		List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
 
-		assertEquals("Invalid number of env vars", 3, envVars.size());
+		assertThat(envVars.size()).as("Invalid number of env vars").isEqualTo(3);
 
 		EnvVar secretKeyRefEnvVar = envVars.get(0);
-		assertEquals("Unexpected env var name", "SECRET_PASSWORD", secretKeyRefEnvVar.getName());
+		assertThat(secretKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("SECRET_PASSWORD");
 		SecretKeySelector secretKeySelector = secretKeyRefEnvVar.getValueFrom().getSecretKeyRef();
-		assertEquals("Unexpected secret name", "mySecret", secretKeySelector.getName());
-		assertEquals("Unexpected secret data key", "myPassword", secretKeySelector.getKey());
+		assertThat(secretKeySelector.getName()).as("Unexpected secret name").isEqualTo("mySecret");
+		assertThat(secretKeySelector.getKey()).as("Unexpected secret data key").isEqualTo("myPassword");
 	}
 
 	@Test
@@ -679,13 +681,13 @@ public class KubernetesAppDeployerTests {
 
 		List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
 
-		assertEquals("Invalid number of env vars", 2, envVars.size());
+		assertThat(envVars.size()).as("Invalid number of env vars").isEqualTo(2);
 
 		EnvVar configMapKeyRefEnvVar = envVars.get(0);
-		assertEquals("Unexpected env var name", "MY_ENV", configMapKeyRefEnvVar.getName());
+		assertThat(configMapKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("MY_ENV");
 		ConfigMapKeySelector configMapKeySelector = configMapKeyRefEnvVar.getValueFrom().getConfigMapKeyRef();
-		assertEquals("Unexpected config map name", "myConfigMap", configMapKeySelector.getName());
-		assertEquals("Unexpected config map data key", "envName", configMapKeySelector.getKey());
+		assertThat(configMapKeySelector.getName()).as("Unexpected config map name").isEqualTo("myConfigMap");
+		assertThat(configMapKeySelector.getKey()).as("Unexpected config map data key").isEqualTo("envName");
 	}
 
 	@Test
@@ -703,19 +705,19 @@ public class KubernetesAppDeployerTests {
 
 		List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
 
-		assertEquals("Invalid number of env vars", 3, envVars.size());
+		assertThat(envVars.size()).as("Invalid number of env vars").isEqualTo(3);
 
 		EnvVar configMapKeyRefEnvVar = envVars.get(0);
-		assertEquals("Unexpected env var name", "MY_ENV", configMapKeyRefEnvVar.getName());
+		assertThat(configMapKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("MY_ENV");
 		ConfigMapKeySelector configMapKeySelector = configMapKeyRefEnvVar.getValueFrom().getConfigMapKeyRef();
-		assertEquals("Unexpected config map name", "myConfigMap", configMapKeySelector.getName());
-		assertEquals("Unexpected config map data key", "envName", configMapKeySelector.getKey());
+		assertThat(configMapKeySelector.getName()).as("Unexpected config map name").isEqualTo("myConfigMap");
+		assertThat(configMapKeySelector.getKey()).as("Unexpected config map data key").isEqualTo("envName");
 
 		configMapKeyRefEnvVar = envVars.get(1);
-		assertEquals("Unexpected env var name", "ENV_VALUES", configMapKeyRefEnvVar.getName());
+		assertThat(configMapKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("ENV_VALUES");
 		configMapKeySelector = configMapKeyRefEnvVar.getValueFrom().getConfigMapKeyRef();
-		assertEquals("Unexpected config map name", "myOtherConfigMap", configMapKeySelector.getName());
-		assertEquals("Unexpected config map data key", "diskType", configMapKeySelector.getKey());
+		assertThat(configMapKeySelector.getName()).as("Unexpected config map name").isEqualTo("myOtherConfigMap");
+		assertThat(configMapKeySelector.getKey()).as("Unexpected config map data key").isEqualTo("diskType");
 	}
 
 	@Test
@@ -735,13 +737,13 @@ public class KubernetesAppDeployerTests {
 
 		List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
 
-		assertEquals("Invalid number of env vars", 2, envVars.size());
+		assertThat(envVars.size()).as("Invalid number of env vars").isEqualTo(2);
 
 		EnvVar configMapKeyRefEnvVar = envVars.get(0);
-		assertEquals("Unexpected env var name", "MY_ENV_GLOBAL", configMapKeyRefEnvVar.getName());
+		assertThat(configMapKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("MY_ENV_GLOBAL");
 		ConfigMapKeySelector configMapKeySelector = configMapKeyRefEnvVar.getValueFrom().getConfigMapKeyRef();
-		assertEquals("Unexpected config map name", "myConfigMapGlobal", configMapKeySelector.getName());
-		assertEquals("Unexpected config data key", "envGlobal", configMapKeySelector.getKey());
+		assertThat(configMapKeySelector.getName()).as("Unexpected config map name").isEqualTo("myConfigMapGlobal");
+		assertThat(configMapKeySelector.getKey()).as("Unexpected config data key").isEqualTo("envGlobal");
 	}
 
 	@Test
@@ -777,28 +779,28 @@ public class KubernetesAppDeployerTests {
 
 		List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
 
-		assertEquals("Invalid number of env vars", 4, envVars.size());
+		assertThat(envVars.size()).as("Invalid number of env vars").isEqualTo(4);
 
 		// deploy prop overrides global
 		EnvVar configMapKeyRefEnvVar = envVars.get(0);
-		assertEquals("Unexpected env var name", "MY_ENV", configMapKeyRefEnvVar.getName());
+		assertThat(configMapKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("MY_ENV");
 		ConfigMapKeySelector configMapKeySelector = configMapKeyRefEnvVar.getValueFrom().getConfigMapKeyRef();
-		assertEquals("Unexpected config map name", "myConfigMap", configMapKeySelector.getName());
-		assertEquals("Unexpected config map data key", "envName", configMapKeySelector.getKey());
+		assertThat(configMapKeySelector.getName()).as("Unexpected config map name").isEqualTo("myConfigMap");
+		assertThat(configMapKeySelector.getKey()).as("Unexpected config map data key").isEqualTo("envName");
 
 		// unique deploy prop
 		configMapKeyRefEnvVar = envVars.get(1);
-		assertEquals("Unexpected env var name", "ENV_VALUES", configMapKeyRefEnvVar.getName());
+		assertThat(configMapKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("ENV_VALUES");
 		configMapKeySelector = configMapKeyRefEnvVar.getValueFrom().getConfigMapKeyRef();
-		assertEquals("Unexpected config map name", "myOtherConfigMap", configMapKeySelector.getName());
-		assertEquals("Unexpected config map data key", "diskType", configMapKeySelector.getKey());
+		assertThat(configMapKeySelector.getName()).as("Unexpected config map name").isEqualTo("myOtherConfigMap");
+		assertThat(configMapKeySelector.getKey()).as("Unexpected config map data key").isEqualTo("diskType");
 
 		// unique, non-overridden global prop
 		configMapKeyRefEnvVar = envVars.get(2);
-		assertEquals("Unexpected env var name", "MY_VALS_GLOBAL", configMapKeyRefEnvVar.getName());
+		assertThat(configMapKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("MY_VALS_GLOBAL");
 		configMapKeySelector = configMapKeyRefEnvVar.getValueFrom().getConfigMapKeyRef();
-		assertEquals("Unexpected config map name", "myValsGlobal", configMapKeySelector.getName());
-		assertEquals("Unexpected config map data key", "valsGlobal", configMapKeySelector.getKey());
+		assertThat(configMapKeySelector.getName()).as("Unexpected config map name").isEqualTo("myValsGlobal");
+		assertThat(configMapKeySelector.getKey()).as("Unexpected config map data key").isEqualTo("valsGlobal");
 	}
 
 	@Test
@@ -811,13 +813,13 @@ public class KubernetesAppDeployerTests {
 
 		List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
 
-		assertEquals("Invalid number of env vars", 3, envVars.size());
+		assertThat(envVars.size()).as("Invalid number of env vars").isEqualTo(3);
 
 		EnvVar configMapKeyRefEnvVar = envVars.get(1);
-		assertEquals("Unexpected env var name", "MY_ENV", configMapKeyRefEnvVar.getName());
+		assertThat(configMapKeyRefEnvVar.getName()).as("Unexpected env var name").isEqualTo("MY_ENV");
 		ConfigMapKeySelector configMapKeySelector = configMapKeyRefEnvVar.getValueFrom().getConfigMapKeyRef();
-		assertEquals("Unexpected config map name", "myConfigMap", configMapKeySelector.getName());
-		assertEquals("Unexpected config map data key", "envName", configMapKeySelector.getKey());
+		assertThat(configMapKeySelector.getName()).as("Unexpected config map name").isEqualTo("myConfigMap");
+		assertThat(configMapKeySelector.getKey()).as("Unexpected config map data key").isEqualTo("envName");
 	}
 
 	@Test
@@ -833,10 +835,10 @@ public class KubernetesAppDeployerTests {
 
 		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
 
-		assertNotNull("Pod security context should not be null", podSecurityContext);
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
 
-		assertEquals("Unexpected run as user", Long.valueOf("65534"), podSecurityContext.getRunAsUser());
-		assertEquals("Unexpected fs group", Long.valueOf("65534"), podSecurityContext.getFsGroup());
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
 	}
 
 	@Test
@@ -866,9 +868,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		NodeAffinity nodeAffinity = podSpec.getAffinity().getNodeAffinity();
-		assertNotNull("Node affinity should not be null", nodeAffinity);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", nodeAffinity.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, nodeAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(nodeAffinity).as("Node affinity should not be null").isNotNull();
+		assertThat(nodeAffinity.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(nodeAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -901,9 +903,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		PodAffinity podAffinity = podSpec.getAffinity().getPodAffinity();
-		assertNotNull("Pod affinity should not be null", podAffinity);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", podAffinity.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, podAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(podAffinity).as("Pod affinity should not be null").isNotNull();
+		assertThat(podAffinity.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(podAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -936,9 +938,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		PodAntiAffinity podAntiAffinity = podSpec.getAffinity().getPodAntiAffinity();
-		assertNotNull("Pod anti-affinity should not be null", podAntiAffinity);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", podAntiAffinity.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, podAntiAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(podAntiAffinity).as("Pod anti-affinity should not be null").isNotNull();
+		assertThat(podAntiAffinity.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(podAntiAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -959,10 +961,10 @@ public class KubernetesAppDeployerTests {
 
 		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
 
-		assertNotNull("Pod security context should not be null", podSecurityContext);
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
 
-		assertEquals("Unexpected run as user", Long.valueOf("65534"), podSecurityContext.getRunAsUser());
-		assertEquals("Unexpected fs group", Long.valueOf("65534"), podSecurityContext.getFsGroup());
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
 	}
 
 	@Test
@@ -1000,9 +1002,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		NodeAffinity nodeAffinityTest = podSpec.getAffinity().getNodeAffinity();
-		assertNotNull("Node affinity should not be null", nodeAffinityTest);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", nodeAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, nodeAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(nodeAffinityTest).as("Node affinity should not be null").isNotNull();
+		assertThat(nodeAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(nodeAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -1040,9 +1042,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		PodAffinity podAffinityTest = podSpec.getAffinity().getPodAffinity();
-		assertNotNull("Pod affinity should not be null", podAffinityTest);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", podAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, podAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(podAffinityTest).as("Pod affinity should not be null").isNotNull();
+		assertThat(podAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(podAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -1080,9 +1082,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		PodAntiAffinity podAntiAffinityTest = podSpec.getAffinity().getPodAntiAffinity();
-		assertNotNull("Pod anti-affinity should not be null", podAntiAffinityTest);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", podAntiAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, podAntiAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(podAntiAffinityTest).as("Pod anti-affinity should not be null").isNotNull();
+		assertThat(podAntiAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(podAntiAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -1095,10 +1097,10 @@ public class KubernetesAppDeployerTests {
 
 		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
 
-		assertNotNull("Pod security context should not be null", podSecurityContext);
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
 
-		assertEquals("Unexpected run as user", Long.valueOf("65534"), podSecurityContext.getRunAsUser());
-		assertEquals("Unexpected fs group", Long.valueOf("65534"), podSecurityContext.getFsGroup());
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
 	}
 
 	@Test
@@ -1110,9 +1112,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		NodeAffinity nodeAffinity = podSpec.getAffinity().getNodeAffinity();
-		assertNotNull("Node affinity should not be null", nodeAffinity);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", nodeAffinity.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, nodeAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(nodeAffinity).as("Node affinity should not be null").isNotNull();
+		assertThat(nodeAffinity.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(nodeAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -1124,9 +1126,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		PodAffinity podAffinity = podSpec.getAffinity().getPodAffinity();
-		assertNotNull("Pod affinity should not be null", podAffinity);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", podAffinity.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, podAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(podAffinity).as("Pod affinity should not be null").isNotNull();
+		assertThat(podAffinity.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(podAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -1138,9 +1140,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		PodAntiAffinity podAntiAffinity = podSpec.getAffinity().getPodAntiAffinity();
-		assertNotNull("Pod anti-affinity should not be null", podAntiAffinity);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", podAntiAffinity.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, podAntiAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(podAntiAffinity).as("Pod anti-affinity should not be null").isNotNull();
+		assertThat(podAntiAffinity.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(podAntiAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -1156,10 +1158,10 @@ public class KubernetesAppDeployerTests {
 
 		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
 
-		assertNotNull("Pod security context should not be null", podSecurityContext);
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
 
-		assertEquals("Unexpected run as user", Long.valueOf("65534"), podSecurityContext.getRunAsUser());
-		assertNull("Unexpected fs group", podSecurityContext.getFsGroup());
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
 	}
 
 	@Test
@@ -1175,10 +1177,10 @@ public class KubernetesAppDeployerTests {
 
 		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
 
-		assertNotNull("Pod security context should not be null", podSecurityContext);
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
 
-		assertNull("Unexpected run as user", podSecurityContext.getRunAsUser());
-		assertEquals("Unexpected fs group", Long.valueOf("65534"), podSecurityContext.getFsGroup());
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
 	}
 
 	@Test
@@ -1202,10 +1204,10 @@ public class KubernetesAppDeployerTests {
 
 		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
 
-		assertNotNull("Pod security context should not be null", podSecurityContext);
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
 
-		assertEquals("Unexpected run as user", Long.valueOf("65534"), podSecurityContext.getRunAsUser());
-		assertEquals("Unexpected fs group", Long.valueOf("65534"), podSecurityContext.getFsGroup());
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
 	}
 
 	@Test
@@ -1253,9 +1255,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		NodeAffinity nodeAffinityTest = podSpec.getAffinity().getNodeAffinity();
-		assertNotNull("Node affinity should not be null", nodeAffinityTest);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", nodeAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, nodeAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(nodeAffinityTest).as("Node affinity should not be null").isNotNull();
+		assertThat(nodeAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(nodeAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -1305,9 +1307,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		PodAffinity podAffinityTest = podSpec.getAffinity().getPodAffinity();
-		assertNotNull("Pod affinity should not be null", podAffinityTest);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", podAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, podAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(podAffinityTest).as("Pod affinity should not be null").isNotNull();
+		assertThat(podAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(podAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test
@@ -1357,9 +1359,9 @@ public class KubernetesAppDeployerTests {
 		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
 
 		PodAntiAffinity podAntiAffinityTest = podSpec.getAffinity().getPodAntiAffinity();
-		assertNotNull("Pod anti-affinity should not be null", podAntiAffinityTest);
-		assertNotNull("RequiredDuringSchedulingIgnoredDuringExecution should not be null", podAntiAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution());
-		assertEquals("PreferredDuringSchedulingIgnoredDuringExecution should have one element", 1, podAntiAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size());
+		assertThat(podAntiAffinityTest).as("Pod anti-affinity should not be null").isNotNull();
+		assertThat(podAntiAffinityTest.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
+		assertThat(podAntiAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesConfigurationPropertiesTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesConfigurationPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,16 @@
 package org.springframework.cloud.deployer.spi.kubernetes;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Ilayaperumal Gopinathan
  * @author Chris Schaefer
  */
 public class KubernetesConfigurationPropertiesTests {
+
 	@Test
 	public void testFabric8Namespacing() {
 		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
@@ -38,10 +39,10 @@ public class KubernetesConfigurationPropertiesTests {
 		KubernetesClient kubernetesClient = KubernetesClientFactory
 				.getKubernetesClient(kubernetesDeployerProperties);
 
-		assertEquals("http://localhost:8090", kubernetesClient.getMasterUrl().toString());
-		assertEquals("testing", kubernetesClient.getNamespace());
-		assertEquals("http://localhost:8090", kubernetesClient.getConfiguration().getMasterUrl());
-		assertEquals(Boolean.TRUE, kubernetesClient.getConfiguration().isTrustCerts());
+		assertThat(kubernetesClient.getMasterUrl().toString()).isEqualTo("http://localhost:8090");
+		assertThat(kubernetesClient.getNamespace()).isEqualTo("testing");
+		assertThat(kubernetesClient.getConfiguration().getMasterUrl()).isEqualTo("http://localhost:8090");
+		assertThat(kubernetesClient.getConfiguration().isTrustCerts()).isTrue();
 	}
 
 	@Test
@@ -54,10 +55,10 @@ public class KubernetesConfigurationPropertiesTests {
 		KubernetesClient kubernetesClient = KubernetesClientFactory
 				.getKubernetesClient(kubernetesDeployerProperties);
 
-		assertEquals("http://localhost:8090", kubernetesClient.getMasterUrl().toString());
-		assertEquals("toplevel", kubernetesClient.getNamespace());
-		assertEquals("http://localhost:8090", kubernetesClient.getConfiguration().getMasterUrl());
-		assertEquals(Boolean.TRUE, kubernetesClient.getConfiguration().isTrustCerts());
+		assertThat(kubernetesClient.getMasterUrl().toString()).isEqualTo("http://localhost:8090");
+		assertThat(kubernetesClient.getNamespace()).isEqualTo("toplevel");
+		assertThat(kubernetesClient.getConfiguration().getMasterUrl()).isEqualTo("http://localhost:8090");
+		assertThat(kubernetesClient.getConfiguration().isTrustCerts()).isTrue();
 	}
 
 	@Test
@@ -71,9 +72,9 @@ public class KubernetesConfigurationPropertiesTests {
 		KubernetesClient kubernetesClient = KubernetesClientFactory
 				.getKubernetesClient(kubernetesDeployerProperties);
 
-		assertEquals("http://localhost:8090", kubernetesClient.getMasterUrl().toString());
-		assertEquals("toplevel", kubernetesClient.getNamespace());
-		assertEquals("http://localhost:8090", kubernetesClient.getConfiguration().getMasterUrl());
-		assertEquals(Boolean.TRUE, kubernetesClient.getConfiguration().isTrustCerts());
+		assertThat(kubernetesClient.getMasterUrl().toString()).isEqualTo("http://localhost:8090");
+		assertThat(kubernetesClient.getNamespace()).isEqualTo("toplevel");
+		assertThat(kubernetesClient.getConfiguration().getMasterUrl()).isEqualTo("http://localhost:8090");
+		assertThat(kubernetesClient.getConfiguration().isTrustCerts()).isTrue();
 	}
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesSchedulerPropertiesTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesSchedulerPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,7 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.util.StringUtils;
 
@@ -35,152 +30,148 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Chris Schaefer
  */
-@RunWith(Enclosed.class)
 public class KubernetesSchedulerPropertiesTests {
-	public static class Tests {
-		@Test
-		public void testImagePullPolicyDefault() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			assertNotNull("Image pull policy should not be null", kubernetesSchedulerProperties.getImagePullPolicy());
-			assertEquals("Invalid default image pull policy", ImagePullPolicy.IfNotPresent,
-					kubernetesSchedulerProperties.getImagePullPolicy());
-		}
 
-		@Test
-		public void testImagePullPolicyCanBeCustomized() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			kubernetesSchedulerProperties.setImagePullPolicy(ImagePullPolicy.Never);
-			assertNotNull("Image pull policy should not be null", kubernetesSchedulerProperties.getImagePullPolicy());
-			assertEquals("Unexpected image pull policy", ImagePullPolicy.Never,
-					kubernetesSchedulerProperties.getImagePullPolicy());
-		}
-
-		@Test
-		public void testRestartPolicyDefault() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			assertNotNull("Restart policy should not be null", kubernetesSchedulerProperties.getRestartPolicy());
-			assertEquals("Invalid default restart policy", RestartPolicy.Never,
-					kubernetesSchedulerProperties.getRestartPolicy());
-		}
-
-		@Test
-		public void testRestartPolicyCanBeCustomized() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			kubernetesSchedulerProperties.setRestartPolicy(RestartPolicy.OnFailure);
-			assertNotNull("Restart policy should not be null", kubernetesSchedulerProperties.getRestartPolicy());
-			assertEquals("Unexpected restart policy", RestartPolicy.OnFailure,
-					kubernetesSchedulerProperties.getRestartPolicy());
-		}
-
-		@Test
-		public void testEntryPointStyleDefault() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			assertNotNull("Entry point style should not be null", kubernetesSchedulerProperties.getEntryPointStyle());
-			assertEquals("Invalid default entry point style", EntryPointStyle.exec,
-					kubernetesSchedulerProperties.getEntryPointStyle());
-		}
-
-		@Test
-		public void testEntryPointStyleCanBeCustomized() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			kubernetesSchedulerProperties.setEntryPointStyle(EntryPointStyle.shell);
-			assertNotNull("Entry point style should not be null", kubernetesSchedulerProperties.getEntryPointStyle());
-			assertEquals("Unexpected entry point stype", EntryPointStyle.shell,
-					kubernetesSchedulerProperties.getEntryPointStyle());
-		}
-
-		@Test
-		public void testNamespaceDefault() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			if (kubernetesSchedulerProperties.getNamespace() == null) {
-				kubernetesSchedulerProperties.setNamespace("default");
-
-				assertTrue("Namespace should not be empty or null",
-						StringUtils.hasText(kubernetesSchedulerProperties.getNamespace()));
-				assertEquals("Invalid default namespace", "default", kubernetesSchedulerProperties.getNamespace());
-			}
-		}
-
-		@Test
-		public void testNamespaceCanBeCustomized() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			kubernetesSchedulerProperties.setNamespace("myns");
-			assertTrue("Namespace should not be empty or null",
-					StringUtils.hasText(kubernetesSchedulerProperties.getNamespace()));
-			assertEquals("Unexpected namespace", "myns", kubernetesSchedulerProperties.getNamespace());
-		}
-
-		@Test
-		public void testImagePullSecretDefault() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			assertNull("No default image pull secret should be set",
-					kubernetesSchedulerProperties.getImagePullSecret());
-		}
-
-		@Test
-		public void testImagePullSecretCanBeCustomized() {
-			String secret = "mysecret";
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			kubernetesSchedulerProperties.setImagePullSecret(secret);
-			assertNotNull("Image pull secret should not be null", kubernetesSchedulerProperties.getImagePullSecret());
-			assertEquals("Unexpected image pull secret", secret, kubernetesSchedulerProperties.getImagePullSecret());
-		}
-
-		@Test
-		public void testEnvironmentVariablesDefault() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			assertEquals("No default environment variables should be set", 0,
-					kubernetesSchedulerProperties.getEnvironmentVariables().length);
-		}
-
-		@Test
-		public void testEnvironmentVariablesCanBeCustomized() {
-			String[] envVars = new String[] { "var1=val1", "var2=val2" };
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			kubernetesSchedulerProperties.setEnvironmentVariables(envVars);
-			assertNotNull("Environment variables should not be null",
-					kubernetesSchedulerProperties.getEnvironmentVariables());
-			assertEquals("Unexpected number of environment variables", 2,
-					kubernetesSchedulerProperties.getEnvironmentVariables().length);
-		}
-
-		@Test
-		public void testTaskServiceAccountNameDefault() {
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			assertNotNull("Task service account name should not be null",
-					kubernetesSchedulerProperties.getTaskServiceAccountName());
-			assertEquals("Unexpected default task service account name",
-					KubernetesSchedulerProperties.DEFAULT_TASK_SERVICE_ACCOUNT_NAME,
-					kubernetesSchedulerProperties.getTaskServiceAccountName());
-		}
-
-		@Test
-		public void testTaskServiceAccountNameCanBeCustomized() {
-			String taskServiceAccountName = "mysa";
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-			kubernetesSchedulerProperties.setTaskServiceAccountName(taskServiceAccountName);
-			assertNotNull("Task service account name should not be null",
-					kubernetesSchedulerProperties.getTaskServiceAccountName());
-			assertEquals("Unexpected task service account name", taskServiceAccountName,
-					kubernetesSchedulerProperties.getTaskServiceAccountName());
-		}
+	@Test
+	public void testImagePullPolicyDefault() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		assertNotNull("Image pull policy should not be null", kubernetesSchedulerProperties.getImagePullPolicy());
+		assertEquals("Invalid default image pull policy", ImagePullPolicy.IfNotPresent,
+				kubernetesSchedulerProperties.getImagePullPolicy());
 	}
 
-	@RunWith(PowerMockRunner.class)
-	@PrepareForTest({ KubernetesSchedulerProperties.class })
-	public static class EnvTests {
-		@Test
-		public void testNamespaceFromEnvironment() throws Exception {
-			PowerMockito.mockStatic(System.class);
-			PowerMockito.when(System.getenv(KubernetesSchedulerProperties.ENV_KEY_KUBERNETES_NAMESPACE))
-					.thenReturn("nsfromenv");
+	@Test
+	public void testImagePullPolicyCanBeCustomized() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		kubernetesSchedulerProperties.setImagePullPolicy(ImagePullPolicy.Never);
+		assertNotNull("Image pull policy should not be null", kubernetesSchedulerProperties.getImagePullPolicy());
+		assertEquals("Unexpected image pull policy", ImagePullPolicy.Never,
+				kubernetesSchedulerProperties.getImagePullPolicy());
+	}
 
-			KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+	@Test
+	public void testRestartPolicyDefault() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		assertNotNull("Restart policy should not be null", kubernetesSchedulerProperties.getRestartPolicy());
+		assertEquals("Invalid default restart policy", RestartPolicy.Never,
+				kubernetesSchedulerProperties.getRestartPolicy());
+	}
+
+	@Test
+	public void testRestartPolicyCanBeCustomized() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		kubernetesSchedulerProperties.setRestartPolicy(RestartPolicy.OnFailure);
+		assertNotNull("Restart policy should not be null", kubernetesSchedulerProperties.getRestartPolicy());
+		assertEquals("Unexpected restart policy", RestartPolicy.OnFailure,
+				kubernetesSchedulerProperties.getRestartPolicy());
+	}
+
+	@Test
+	public void testEntryPointStyleDefault() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		assertNotNull("Entry point style should not be null", kubernetesSchedulerProperties.getEntryPointStyle());
+		assertEquals("Invalid default entry point style", EntryPointStyle.exec,
+				kubernetesSchedulerProperties.getEntryPointStyle());
+	}
+
+	@Test
+	public void testEntryPointStyleCanBeCustomized() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		kubernetesSchedulerProperties.setEntryPointStyle(EntryPointStyle.shell);
+		assertNotNull("Entry point style should not be null", kubernetesSchedulerProperties.getEntryPointStyle());
+		assertEquals("Unexpected entry point stype", EntryPointStyle.shell,
+				kubernetesSchedulerProperties.getEntryPointStyle());
+	}
+
+	@Test
+	public void testNamespaceDefault() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		if (kubernetesSchedulerProperties.getNamespace() == null) {
+			kubernetesSchedulerProperties.setNamespace("default");
 
 			assertTrue("Namespace should not be empty or null",
 					StringUtils.hasText(kubernetesSchedulerProperties.getNamespace()));
-			assertEquals("Unexpected namespace from environment", "nsfromenv",
-					kubernetesSchedulerProperties.getNamespace());
+			assertEquals("Invalid default namespace", "default", kubernetesSchedulerProperties.getNamespace());
 		}
 	}
+
+	@Test
+	public void testNamespaceCanBeCustomized() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		kubernetesSchedulerProperties.setNamespace("myns");
+		assertTrue("Namespace should not be empty or null",
+				StringUtils.hasText(kubernetesSchedulerProperties.getNamespace()));
+		assertEquals("Unexpected namespace", "myns", kubernetesSchedulerProperties.getNamespace());
+	}
+
+	@Test
+	public void testImagePullSecretDefault() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		assertNull("No default image pull secret should be set", kubernetesSchedulerProperties.getImagePullSecret());
+	}
+
+	@Test
+	public void testImagePullSecretCanBeCustomized() {
+		String secret = "mysecret";
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		kubernetesSchedulerProperties.setImagePullSecret(secret);
+		assertNotNull("Image pull secret should not be null", kubernetesSchedulerProperties.getImagePullSecret());
+		assertEquals("Unexpected image pull secret", secret, kubernetesSchedulerProperties.getImagePullSecret());
+	}
+
+	@Test
+	public void testEnvironmentVariablesDefault() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		assertEquals("No default environment variables should be set", 0,
+				kubernetesSchedulerProperties.getEnvironmentVariables().length);
+	}
+
+	@Test
+	public void testEnvironmentVariablesCanBeCustomized() {
+		String[] envVars = new String[] { "var1=val1", "var2=val2" };
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		kubernetesSchedulerProperties.setEnvironmentVariables(envVars);
+		assertNotNull("Environment variables should not be null",
+				kubernetesSchedulerProperties.getEnvironmentVariables());
+		assertEquals("Unexpected number of environment variables", 2,
+				kubernetesSchedulerProperties.getEnvironmentVariables().length);
+	}
+
+	@Test
+	public void testTaskServiceAccountNameDefault() {
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		assertNotNull("Task service account name should not be null",
+				kubernetesSchedulerProperties.getTaskServiceAccountName());
+		assertEquals("Unexpected default task service account name",
+				KubernetesSchedulerProperties.DEFAULT_TASK_SERVICE_ACCOUNT_NAME,
+				kubernetesSchedulerProperties.getTaskServiceAccountName());
+	}
+
+	@Test
+	public void testTaskServiceAccountNameCanBeCustomized() {
+		String taskServiceAccountName = "mysa";
+		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		kubernetesSchedulerProperties.setTaskServiceAccountName(taskServiceAccountName);
+		assertNotNull("Task service account name should not be null",
+				kubernetesSchedulerProperties.getTaskServiceAccountName());
+		assertEquals("Unexpected task service account name", taskServiceAccountName,
+				kubernetesSchedulerProperties.getTaskServiceAccountName());
+	}
+
+	// Re-implement when we have a proper env binding via boot
+	// @RunWith(PowerMockRunner.class)
+	// @PrepareForTest({ KubernetesSchedulerProperties.class })
+	// public static class EnvTests {
+	// 	@Test
+	// 	public void testNamespaceFromEnvironment() throws Exception {
+	// 		PowerMockito.mockStatic(System.class);
+	// 		PowerMockito.when(System.getenv(KubernetesSchedulerProperties.ENV_KEY_KUBERNETES_NAMESPACE))
+	// 				.thenReturn("nsfromenv");
+	// 		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+	// 		assertTrue("Namespace should not be empty or null",
+	// 				StringUtils.hasText(kubernetesSchedulerProperties.getNamespace()));
+	// 		assertEquals("Unexpected namespace from environment", "nsfromenv",
+	// 				kubernetesSchedulerProperties.getNamespace());
+	// 	}
+	// }
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherMaximumConcurrentTasksTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherMaximumConcurrentTasksTests.java
@@ -1,4 +1,20 @@
-package org.springframework.cloud.deployer.spi.kubernetes;
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package org.springframework.cloud.deployer.spi.kubernetes;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -11,10 +27,8 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,9 +37,10 @@ import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.core.io.Resource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -35,7 +50,7 @@ import static org.mockito.Mockito.when;
  **/
 @SpringBootTest(classes = { KubernetesAutoConfiguration.class }, properties = {
 		"spring.cloud.deployer.kubernetes.maximum-concurrent-tasks=10" })
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class KubernetesTaskLauncherMaximumConcurrentTasksTests {
 
 	@Autowired
@@ -45,9 +60,6 @@ public class KubernetesTaskLauncherMaximumConcurrentTasksTests {
 	private KubernetesClient client;
 
 	private List<Pod> pods;
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	@Test
 	public void getMaximumConcurrentTasksExceeded() {
@@ -81,15 +93,15 @@ public class KubernetesTaskLauncherMaximumConcurrentTasksTests {
 
 		assertThat(taskLauncher.getMaximumConcurrentTasks()).isEqualTo(taskLauncher.getRunningTaskExecutionCount());
 
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage(
-				"Cannot launch task task. The maximum concurrent task executions is at its limit [10].");
-
 		AppDefinition appDefinition = new AppDefinition("task", Collections.emptyMap());
 		AppDeploymentRequest request = new AppDeploymentRequest(appDefinition, mock(Resource.class),
 				Collections.emptyMap());
 
-		taskLauncher.launch(request);
+		assertThatThrownBy(() -> {
+			taskLauncher.launch(request);
+		}).isInstanceOf(IllegalStateException.class).hasMessageContaining(
+				"Cannot launch task task. The maximum concurrent task executions is at its limit [10].");
+
 	}
 
 	private List<Pod> stubForRunningPods(int numTasks) {

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/PropertyParserUtilsTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/PropertyParserUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 
 package org.springframework.cloud.deployer.spi.kubernetes;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.deployer.spi.kubernetes.support.PropertyParserUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for PropertyParserUtils
@@ -37,21 +37,21 @@ public class PropertyParserUtilsTests {
 	@Test
 	public void testAnnotationParseSingle() {
 		Map<String, String> annotations = PropertyParserUtils.getStringPairsToMap("annotation:value");
-		assertFalse(annotations.isEmpty());
-		assertTrue(annotations.size() == 1);
-		assertTrue(annotations.containsKey("annotation"));
-		assertTrue(annotations.get("annotation").equals("value"));
+		assertThat(annotations.isEmpty()).isFalse();
+		assertThat(annotations.size() == 1).isTrue();
+		assertThat(annotations.containsKey("annotation")).isTrue();
+		assertThat(annotations.get("annotation").equals("value")).isTrue();
 	}
 
 	@Test
 	public void testAnnotationParseMultiple() {
 		Map<String, String> annotations = PropertyParserUtils.getStringPairsToMap("annotation1:value1,annotation2:value2");
-		assertFalse(annotations.isEmpty());
-		assertTrue(annotations.size() == 2);
-		assertTrue(annotations.containsKey("annotation1"));
-		assertTrue(annotations.get("annotation1").equals("value1"));
-		assertTrue(annotations.containsKey("annotation2"));
-		assertTrue(annotations.get("annotation2").equals("value2"));
+		assertThat(annotations.isEmpty()).isFalse();
+		assertThat(annotations.size() == 2).isTrue();
+		assertThat(annotations.containsKey("annotation1")).isTrue();
+		assertThat(annotations.get("annotation1").equals("value1")).isTrue();
+		assertThat(annotations.containsKey("annotation2")).isTrue();
+		assertThat(annotations.get("annotation2").equals("value2")).isTrue();
 	}
 
 	@Test
@@ -59,19 +59,21 @@ public class PropertyParserUtilsTests {
 		String annotation = "iam.amazonaws.com/role:arn:aws:iam::12345678:role/role-name,key1:val1:val2:val3," +
 				"key2:val4::val5:val6::val7:val8";
 		Map<String, String> annotations = PropertyParserUtils.getStringPairsToMap(annotation);
-		assertFalse(annotations.isEmpty());
-		assertTrue(annotations.size() == 3);
-		assertTrue(annotations.containsKey("iam.amazonaws.com/role"));
-		assertTrue(annotations.get("iam.amazonaws.com/role").equals("arn:aws:iam::12345678:role/role-name"));
-		assertTrue(annotations.containsKey("key1"));
-		assertTrue(annotations.get("key1").equals("val1:val2:val3"));
-		assertTrue(annotations.containsKey("key2"));
-		assertTrue(annotations.get("key2").equals("val4::val5:val6::val7:val8"));
+		assertThat(annotations.isEmpty()).isFalse();
+		assertThat(annotations.size() == 3).isTrue();
+		assertThat(annotations.containsKey("iam.amazonaws.com/role")).isTrue();
+		assertThat(annotations.get("iam.amazonaws.com/role").equals("arn:aws:iam::12345678:role/role-name")).isTrue();
+		assertThat(annotations.containsKey("key1")).isTrue();
+		assertThat(annotations.get("key1").equals("val1:val2:val3")).isTrue();
+		assertThat(annotations.containsKey("key2")).isTrue();
+		assertThat(annotations.get("key2").equals("val4::val5:val6::val7:val8")).isTrue();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testAnnotationParseInvalidValue() {
-		PropertyParserUtils.getStringPairsToMap("annotation1:value1,annotation2,annotation3:value3");
+		assertThatThrownBy(() -> {
+			PropertyParserUtils.getStringPairsToMap("annotation1:value1,annotation2,annotation3:value3");
+		}).isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test
@@ -83,10 +85,10 @@ public class PropertyParserUtilsTests {
 		deploymentProps.put("spring.cloud.deployer.kubernetes.init-container.image-name", "springcloud/openjdk");
 		deploymentProps.put("spring.cloud.deployer.kubernetes.initContainer.containerName", "test");
 		deploymentProps.put("spring.cloud.deployer.kubernetes.init-container.commands", "['sh','echo hello']");
-		assertTrue(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.podAnnotations").equals("key1:value1,key2:value2"));
-		assertTrue(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.serviceAnnotations").equals("key3:value3,key4:value4"));
-		assertTrue(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.initContainer.imageName").equals("springcloud/openjdk"));
-		assertTrue(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.initContainer.imageName").equals("springcloud/openjdk"));
-		assertTrue(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.imagePullPolicy").equals("Never"));
+		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.podAnnotations").equals("key1:value1,key2:value2")).isTrue();
+		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.serviceAnnotations").equals("key3:value3,key4:value4")).isTrue();
+		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.initContainer.imageName").equals("springcloud/openjdk")).isTrue();
+		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.initContainer.imageName").equals("springcloud/openjdk")).isTrue();
+		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.imagePullPolicy").equals("Never")).isTrue();
 	}
 }

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/RunAbstractKubernetesDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/RunAbstractKubernetesDeployerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.Quantity;
-import org.hamcrest.MatcherAssert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.deployer.spi.core.AppDefinition;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.core.io.FileSystemResource;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit test for {@link AbstractKubernetesDeployer}.
@@ -48,7 +45,7 @@ public class RunAbstractKubernetesDeployerTests {
 	private DeploymentPropertiesResolver deploymentPropertiesResolver;
 
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		this.deploymentProperties = new HashMap<>();
 		this.deploymentRequest = new AppDeploymentRequest(new AppDefinition("foo", Collections.emptyMap()), new FileSystemResource(""), deploymentProperties);
@@ -61,21 +58,21 @@ public class RunAbstractKubernetesDeployerTests {
 	public void deduceImagePullPolicy_fallsBackToIfNotPresentIfOverrideNotParseable() {
 		deploymentProperties.put("spring.cloud.deployer.kubernetes.imagePullPolicy", "not-a-real-value");
 		ImagePullPolicy pullPolicy = this.deploymentPropertiesResolver.deduceImagePullPolicy(deploymentRequest.getDeploymentProperties());
-		assertThat(pullPolicy, is(ImagePullPolicy.IfNotPresent));
+		assertThat(pullPolicy).isEqualTo(ImagePullPolicy.IfNotPresent);
 	}
 
 	@Test
 	public void limitGpu_noDeploymentProperty_incompleteServerProperty1_noGpu() {
 		kubernetesDeployerProperties.getLimits().setGpuVendor("nvidia.com");
 		Map<String, Quantity> limits = this.deploymentPropertiesResolver.deduceResourceLimits(deploymentRequest.getDeploymentProperties());
-		assertNull(limits.get("nvidia.com/gpu"));
+		assertThat(limits.get("nvidia.com/gpu")).isNull();
 	}
 
 	@Test
 	public void limitGpu_noDeploymentProperty_incompleteServerProperty2_noGpu() {
 		kubernetesDeployerProperties.getLimits().setGpuCount("2");
 		Map<String, Quantity> limits = this.deploymentPropertiesResolver.deduceResourceLimits(deploymentRequest.getDeploymentProperties());
-		assertNull(limits.get("nvidia.com/gpu"));
+		assertThat(limits.get("nvidia.com/gpu")).isNull();
 	}
 
 	@Test
@@ -83,7 +80,7 @@ public class RunAbstractKubernetesDeployerTests {
 		kubernetesDeployerProperties.getLimits().setGpuVendor("nvidia.com");
 		kubernetesDeployerProperties.getLimits().setGpuCount("2");
 		Map<String, Quantity> limits = this.deploymentPropertiesResolver.deduceResourceLimits(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(limits.get("nvidia.com/gpu"), is(new Quantity("2")));
+		assertThat(limits.get("nvidia.com/gpu")).isEqualTo(new Quantity("2"));
 	}
 
 	@Test
@@ -92,7 +89,7 @@ public class RunAbstractKubernetesDeployerTests {
 		kubernetesDeployerProperties.getLimits().setGpuCount("2");
 		deploymentProperties.put("spring.cloud.deployer.kubernetes.limits.gpu_vendor", "ati.com");
 		Map<String, Quantity> limits = this.deploymentPropertiesResolver.deduceResourceLimits(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(limits.get("ati.com/gpu"), is(new Quantity("2")));
+		assertThat(limits.get("ati.com/gpu")).isEqualTo(new Quantity("2"));
 	}
 
 	@Test
@@ -101,7 +98,7 @@ public class RunAbstractKubernetesDeployerTests {
 		kubernetesDeployerProperties.getLimits().setGpuCount("2");
 		deploymentProperties.put("spring.cloud.deployer.kubernetes.limits.gpu_count", "1");
 		Map<String, Quantity> limits = this.deploymentPropertiesResolver.deduceResourceLimits(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(limits.get("nvidia.com/gpu"), is(new Quantity("1")));
+		assertThat(limits.get("nvidia.com/gpu")).isEqualTo(new Quantity("1"));
 	}
 
 	@Test
@@ -111,21 +108,21 @@ public class RunAbstractKubernetesDeployerTests {
 		deploymentProperties.put("spring.cloud.deployer.kubernetes.limits.gpu_vendor", "ati.com");
 		deploymentProperties.put("spring.cloud.deployer.kubernetes.limits.gpu_count", "1");
 		Map<String, Quantity> limits = this.deploymentPropertiesResolver.deduceResourceLimits(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(limits.get("ati.com/gpu"), is(new Quantity("1")));
+		assertThat(limits.get("ati.com/gpu")).isEqualTo(new Quantity("1"));
 	}
 
 	@Test
 	public void limitCpu_noDeploymentProperty_serverProperty_usesServerProperty() {
 		kubernetesDeployerProperties.getLimits().setCpu("400m");
 		Map<String, Quantity> limits = this.deploymentPropertiesResolver.deduceResourceLimits(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(limits.get("cpu"), is(new Quantity("400m")));
+		assertThat(limits.get("cpu")).isEqualTo(new Quantity("400m"));
 	}
 
 	@Test
 	public void limitMemory_noDeploymentProperty_serverProperty_usesServerProperty() {
 		kubernetesDeployerProperties.getLimits().setMemory("540Mi");
 		Map<String, Quantity> limits = this.deploymentPropertiesResolver.deduceResourceLimits(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(limits.get("memory"), is(new Quantity("540Mi")));
+		assertThat(limits.get("memory")).isEqualTo(new Quantity("540Mi"));
 	}
 
 	@Test
@@ -133,7 +130,7 @@ public class RunAbstractKubernetesDeployerTests {
 		kubernetesDeployerProperties.getLimits().setCpu("100m");
 		deploymentProperties.put("spring.cloud.deployer.kubernetes.limits.cpu", "400m");
 		Map<String, Quantity> limits = this.deploymentPropertiesResolver.deduceResourceLimits(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(limits.get("cpu"), is(new Quantity("400m")));
+		assertThat(limits.get("cpu")).isEqualTo(new Quantity("400m"));
 	}
 
 	@Test
@@ -141,21 +138,21 @@ public class RunAbstractKubernetesDeployerTests {
 		kubernetesDeployerProperties.getLimits().setMemory("640Mi");
 		deploymentProperties.put("spring.cloud.deployer.kubernetes.limits.memory", "256Mi");
 		Map<String, Quantity> limits = this.deploymentPropertiesResolver.deduceResourceLimits(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(limits.get("memory"), is(new Quantity("256Mi")));
+		assertThat(limits.get("memory")).isEqualTo(new Quantity("256Mi"));
 	}
 
 	@Test
 	public void requestCpu_noDeploymentProperty_serverProperty_usesServerProperty() {
 		kubernetesDeployerProperties.getRequests().setCpu("400m");
 		Map<String, Quantity> requests = this.deploymentPropertiesResolver.deduceResourceRequests(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(requests.get("cpu"), is(new Quantity("400m")));
+		assertThat(requests.get("cpu")).isEqualTo(new Quantity("400m"));
 	}
 
 	@Test
 	public void requestMemory_noDeploymentProperty_serverProperty_usesServerProperty() {
 		kubernetesDeployerProperties.getRequests().setMemory("120Mi");
 		Map<String, Quantity> requests = this.deploymentPropertiesResolver.deduceResourceRequests(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(requests.get("memory"), is(new Quantity("120Mi")));
+		assertThat(requests.get("memory")).isEqualTo(new Quantity("120Mi"));
 	}
 
 	@Test
@@ -163,7 +160,7 @@ public class RunAbstractKubernetesDeployerTests {
 		kubernetesDeployerProperties.getRequests().setCpu("1000m");
 		deploymentProperties.put("spring.cloud.deployer.kubernetes.requests.cpu", "461m");
 		Map<String, Quantity> requests = this.deploymentPropertiesResolver.deduceResourceRequests(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(requests.get("cpu"), is(new Quantity("461m")));
+		assertThat(requests.get("cpu")).isEqualTo(new Quantity("461m"));
 	}
 
 	@Test
@@ -171,6 +168,6 @@ public class RunAbstractKubernetesDeployerTests {
 		kubernetesDeployerProperties.getRequests().setMemory("640Mi");
 		deploymentProperties.put("spring.cloud.deployer.kubernetes.requests.memory", "256Mi");
 		Map<String, Quantity> requests = this.deploymentPropertiesResolver.deduceResourceRequests(deploymentRequest.getDeploymentProperties());
-		MatcherAssert.assertThat(requests.get("memory"), is(new Quantity("256Mi")));
+		assertThat(requests.get("memory")).isEqualTo(new Quantity("256Mi"));
 	}
 }


### PR DESCRIPTION
- Migration to junit5, assertj, etc
- Tests needing k8s are ran via failsafe
- Fixes #443