### PR TITLE
Support PodAnnotations & Labels to cronjob pod template spec

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
@@ -596,8 +596,13 @@ class DeploymentPropertiesResolver {
 		String deploymentLabels = PropertyParserUtils.getDeploymentPropertyValue(kubernetesDeployerProperties,
 				this.propertyPrefix + ".deploymentLabels", "");
 
-		if (StringUtils.hasText(deploymentLabels)) {
-			String[] deploymentLabel = deploymentLabels.split(",");
+		// Add deployment labels set at the deployer level.
+		String updatedLabels = StringUtils.hasText(this.properties.getDeploymentLabels()) ?
+				new StringBuilder().append(deploymentLabels).append(StringUtils.hasText(deploymentLabels) ? ",": "")
+						.append(this.properties.getDeploymentLabels()).toString() : deploymentLabels;
+
+		if (StringUtils.hasText(updatedLabels)) {
+			String[] deploymentLabel = updatedLabels.split(",");
 
 			for (String label : deploymentLabel) {
 				String[] labelPair = label.split(":");
@@ -606,7 +611,6 @@ class DeploymentPropertiesResolver {
 				labels.put(labelPair[0].trim(), labelPair[1].trim());
 			}
 		}
-
 		return labels;
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -782,6 +782,11 @@ public class KubernetesDeployerProperties {
 	 */
 	private List<Container> additionalContainers;
 
+	/**
+	 * Deployment label to be applied to Deployment, StatefulSet, JobSpec etc.,
+	 */
+	private String deploymentLabels;
+
 	public String getNamespace() {
 		return namespace;
 	}
@@ -1437,5 +1442,13 @@ public class KubernetesDeployerProperties {
 
 	void setLifecycle(Lifecycle lifecycle) {
 		this.lifecycle = lifecycle;
+	}
+
+	public String getDeploymentLabels() {
+		return deploymentLabels;
+	}
+
+	public void setDeploymentLabels(String deploymentLabels) {
+		this.deploymentLabels = deploymentLabels;
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesScheduler.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesScheduler.java
@@ -49,7 +49,7 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  */
 public class KubernetesScheduler extends AbstractKubernetesDeployer implements Scheduler {
-	private static final String SPRING_CRONJOB_ID_KEY = "spring-cronjob-id";
+	protected static final String SPRING_CRONJOB_ID_KEY = "spring-cronjob-id";
 
 	private static final String SCHEDULE_EXPRESSION_FIELD_NAME = "spec.schedule";
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesScheduler.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesScheduler.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.deployer.spi.kubernetes;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -167,8 +166,8 @@ public class KubernetesScheduler extends AbstractKubernetesDeployer implements S
 	}
 
 	protected CronJob createCronJob(ScheduleRequest scheduleRequest) {
-		Map<String, String> labels = Collections.singletonMap(SPRING_CRONJOB_ID_KEY,
-				scheduleRequest.getDefinition().getName());
+		Map<String, String> labels = new HashMap<>();
+		labels.put(SPRING_CRONJOB_ID_KEY, scheduleRequest.getDefinition().getName());
 
 		Map<String, String> schedulerProperties = scheduleRequest.getSchedulerProperties();
 		String schedule = schedulerProperties.get(SchedulerPropertyKeys.CRON_EXPRESSION);
@@ -179,11 +178,14 @@ public class KubernetesScheduler extends AbstractKubernetesDeployer implements S
 		if (StringUtils.hasText(taskServiceAccountName)) {
 			podSpec.setServiceAccountName(taskServiceAccountName);
 		}
+		Map<String, String> annotations = this.deploymentPropertiesResolver.getPodAnnotations(scheduleRequest.getSchedulerProperties());
+		labels.putAll(this.deploymentPropertiesResolver.getDeploymentLabels(scheduleRequest.getSchedulerProperties()));
 
 		CronJob cronJob = new CronJobBuilder().withNewMetadata().withName(scheduleRequest.getScheduleName())
 				.withLabels(labels).withAnnotations(this.deploymentPropertiesResolver.getJobAnnotations(schedulerProperties)).endMetadata()
 				.withNewSpec().withSchedule(schedule).withNewJobTemplate()
-				.withNewSpec().withNewTemplate().withSpec(podSpec).endTemplate().endSpec()
+				.withNewSpec().withNewTemplate().withNewMetadata().addToAnnotations(annotations).addToLabels(labels)
+				.endMetadata().withSpec(podSpec).endTemplate().endSpec()
 				.endJobTemplate().endSpec().build();
 
 		setImagePullSecret(scheduleRequest, cronJob);

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -237,6 +237,9 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 		PodSpec podSpec = createPodSpec(request);
 
 		podSpec.setRestartPolicy(getRestartPolicy(request).name());
+		Map<String, String> annotations = new HashMap<>();
+		annotations.putAll(this.deploymentPropertiesResolver.getJobAnnotations(deploymentProperties));
+		annotations.putAll(this.deploymentPropertiesResolver.getPodAnnotations(deploymentProperties));
 		if (this.properties.isCreateJob()) {
 			logger.debug(String.format("Launching Job for task: %s", appId));
 			ObjectMeta objectMeta = new ObjectMetaBuilder()
@@ -244,6 +247,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 					.addToLabels(idMap)
 					.addToLabels(deploymentLabels)
 					.withAnnotations(this.deploymentPropertiesResolver.getJobAnnotations(deploymentProperties))
+					.addToAnnotations(this.deploymentPropertiesResolver.getPodAnnotations(deploymentProperties))
 					.build();
 			PodTemplateSpec podTemplateSpec = new PodTemplateSpec(objectMeta, podSpec);
 
@@ -265,6 +269,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 		}
 		else {
 			logger.debug(String.format("Launching Pod for task: %s", appId));
+
 			this.client.pods()
 					.createNew()
 					.withNewMetadata()
@@ -272,6 +277,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 					.withLabels(podLabelMap)
 					.addToLabels(deploymentLabels)
 					.withAnnotations(this.deploymentPropertiesResolver.getJobAnnotations(deploymentProperties))
+					.addToAnnotations(this.deploymentPropertiesResolver.getPodAnnotations(deploymentProperties))
 					.addToLabels(idMap)
 					.endMetadata()
 					.withSpec(podSpec)


### PR DESCRIPTION
 - Add support to add labels as well as pod annotations to the underlying pod template spec metadata
 - Add tests

Resolves #445
Resolves #425