### PR TITLE
Adding Env Variable to a Init Containers

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -405,6 +405,11 @@ public class KubernetesDeployerProperties {
 
 		private List<VolumeMount> volumeMounts;
 
+		/**
+		 * Environment variables to set for any deployed init container.
+		 */
+		private String[] environmentVariables = new String[] {};
+
 		public String getImageName() {
 			return imageName;
 		}
@@ -435,6 +440,14 @@ public class KubernetesDeployerProperties {
 
 		public void setVolumeMounts(List<VolumeMount> volumeMounts) {
 			this.volumeMounts = volumeMounts;
+		}
+
+		public String[] getEnvironmentVariables() {
+			return environmentVariables;
+		}
+
+		public void setEnvironmentVariables(String[] environmentVariables) {
+			this.environmentVariables = environmentVariables;
 		}
 	}
 

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationIT.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationIT.java
@@ -1358,13 +1358,6 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
 
 		Container testInitContainer = initContainer.get();
 
-		assertThat(testInitContainer.getName()).as("Unexpected init container name").isEqualTo("test");
-		assertThat(testInitContainer.getImage()).as("Unexpected init container image").isEqualTo("busybox:latest");
-
-		List<String> commands = testInitContainer.getCommand();
-
-		assertThat(commands).contains("sh", "-c", "echo hello");
-
 		List<EnvVar> containerEnvs = testInitContainer.getEnv();
 
 		assertThat(containerEnvs).hasSize(2);

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationIT.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationIT.java
@@ -1330,6 +1330,58 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
 	}
 
 	@Test
+	public void testCreateInitContainerWithEnvVariables() {
+		log.info("Testing {}...", "CreateInitContainer");
+		KubernetesAppDeployer kubernetesAppDeployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(),
+				kubernetesClient);
+
+		Map<String, String> props = Collections.singletonMap("spring.cloud.deployer.kubernetes.initContainer",
+				"{containerName: 'test', imageName: 'busybox:latest', commands: ['sh', '-c', 'echo hello'], environmentVariables: ['KEY1=VAL1', 'KEY2=VAL2']}");
+
+		AppDefinition definition = new AppDefinition(randomName(), null);
+		AppDeploymentRequest request = new AppDeploymentRequest(definition, testApplication(), props);
+
+		log.info("Deploying {}...", request.getDefinition().getName());
+		String deploymentId = kubernetesAppDeployer.deploy(request);
+		Timeout timeout = deploymentTimeout();
+		await().pollInterval(Duration.ofMillis(timeout.pause))
+				.atMost(Duration.ofMillis(timeout.maxAttempts * timeout.pause))
+				.untilAsserted(() -> {
+					assertThat(appDeployer().status(deploymentId).getState()).isEqualTo(DeploymentState.deployed);
+				});
+
+		Deployment deployment = kubernetesClient.apps().deployments().withName(request.getDefinition().getName()).get();
+		List<Container> initContainers = deployment.getSpec().getTemplate().getSpec().getInitContainers();
+
+		Optional<Container> initContainer = initContainers.stream().filter(i -> i.getName().equals("test")).findFirst();
+		assertThat(initContainer.isPresent()).as("Init container not found").isTrue();
+
+		Container testInitContainer = initContainer.get();
+
+		assertThat(testInitContainer.getName()).as("Unexpected init container name").isEqualTo("test");
+		assertThat(testInitContainer.getImage()).as("Unexpected init container image").isEqualTo("busybox:latest");
+
+		List<String> commands = testInitContainer.getCommand();
+
+		assertThat(commands).contains("sh", "-c", "echo hello");
+
+		List<EnvVar> containerEnvs = testInitContainer.getEnv();
+
+		assertThat(containerEnvs).hasSize(2);
+		assertThat(containerEnvs.stream().map(EnvVar::getName).collect(Collectors.toList())).contains("KEY1", "KEY2");
+		assertThat(containerEnvs.stream().map(EnvVar::getValue).collect(Collectors.toList())).contains("VAL1", "VAL2");
+
+		log.info("Undeploying {}...", deploymentId);
+		timeout = undeploymentTimeout();
+		kubernetesAppDeployer.undeploy(deploymentId);
+		await().pollInterval(Duration.ofMillis(timeout.pause))
+				.atMost(Duration.ofMillis(timeout.maxAttempts * timeout.pause))
+				.untilAsserted(() -> {
+					assertThat(appDeployer().status(deploymentId).getState()).isEqualTo(DeploymentState.unknown);
+				});
+	}
+
+	@Test
 	public void testCreateInitContainerWithVolumeMounts() {
 		log.info("Testing {}...", "CreateInitContainerWithVolumeMounts");
 		KubernetesAppDeployer kubernetesAppDeployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(),


### PR DESCRIPTION
  - introduce new init-container environment-variables property to mirror the same property inn the main container.
  - add integration test.

  Resolves #441