### PR TITLE
Deprecate scheduler properties

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -45,7 +45,6 @@ import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.kubernetes.support.PropertyParserUtils;
-import org.springframework.cloud.deployer.spi.scheduler.ScheduleRequest;
 import org.springframework.cloud.deployer.spi.util.RuntimeVersionUtils;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
@@ -180,8 +179,7 @@ public class AbstractKubernetesDeployer {
 
 		String appId = createDeploymentId(appDeploymentRequest);
 
-		Map<String, String>  deploymentProperties = (appDeploymentRequest instanceof ScheduleRequest) ?
-				((ScheduleRequest) appDeploymentRequest).getSchedulerProperties() : appDeploymentRequest.getDeploymentProperties();
+		Map<String, String>  deploymentProperties = appDeploymentRequest.getDeploymentProperties();
 
 		PodSpecBuilder podSpec = new PodSpecBuilder();
 
@@ -256,10 +254,10 @@ public class AbstractKubernetesDeployer {
 
 		podSpec.withRestartPolicy(this.deploymentPropertiesResolver.getRestartPolicy(deploymentProperties).name());
 
-		String deploymentServiceAcccountName = this.deploymentPropertiesResolver.getDeploymentServiceAccountName(deploymentProperties);
+		String deploymentServiceAccountName = this.deploymentPropertiesResolver.getDeploymentServiceAccountName(deploymentProperties);
 
-		if (deploymentServiceAcccountName != null) {
-			podSpec.withServiceAccountName(deploymentServiceAcccountName);
+		if (deploymentServiceAccountName != null) {
+			podSpec.withServiceAccountName(deploymentServiceAccountName);
 		}
 
 		PodSecurityContext podSecurityContext = this.deploymentPropertiesResolver.getPodSecurityContext(deploymentProperties);
@@ -315,7 +313,7 @@ public class AbstractKubernetesDeployer {
 		String secretName = PropertyParserUtils.getDeploymentPropertyValue(kubernetesDeployerProperties,
 				this.deploymentPropertiesResolver.getPropertyPrefix() + ".probeCredentialsSecret");
 
-		if (!StringUtils.isEmpty(secretName)) {
+		if (StringUtils.hasText(secretName)) {
 			return this.client.secrets().withName(secretName).get();
 		}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -280,7 +280,7 @@ public class DefaultContainerFactory implements ContainerFactory {
 		// add properties from deployment request
 		Map<String, String> args = request.getDefinition().getProperties();
 		for (Map.Entry<String, String> entry : args.entrySet()) {
-			if (StringUtils.isEmpty(entry.getValue())) {
+			if (!StringUtils.hasText(entry.getValue())) {
 				logger.warn(
 						"Excluding request property with missing value from command args: " + entry.getKey());
 			}
@@ -302,13 +302,14 @@ public class DefaultContainerFactory implements ContainerFactory {
 
 
 	private DeploymentPropertiesResolver getDeploymentPropertiesResolver(AppDeploymentRequest request) {
-		String propertiesPrefix = (request instanceof ScheduleRequest) ? KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX :
+		String propertiesPrefix = (request instanceof ScheduleRequest &&
+				((ScheduleRequest) request).getSchedulerProperties() != null &&
+				((ScheduleRequest) request).getSchedulerProperties().size() > 0 ) ? KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX :
 				KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX;
 		return new DeploymentPropertiesResolver(propertiesPrefix, this.properties);
 	}
 
 	private Map<String, String> getDeploymentProperties(AppDeploymentRequest request) {
-		return (request instanceof ScheduleRequest) ? ((ScheduleRequest)request).getSchedulerProperties() :
-				request.getDeploymentProperties();
+		return request.getDeploymentProperties();
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -465,6 +465,59 @@ public class KubernetesDeployerProperties {
 	}
 
 	/**
+	 * The {@link RestartPolicy} to use. Defaults to {@link RestartPolicy#Never}.
+	 */
+	private RestartPolicy restartPolicy = RestartPolicy.Never;
+
+	/**
+	 * The default service account name to use for tasks.
+	 */
+	protected static final String DEFAULT_TASK_SERVICE_ACCOUNT_NAME = "default";
+
+	/**
+	 * Service account name to use for tasks, defaults to:
+	 * {@link #DEFAULT_TASK_SERVICE_ACCOUNT_NAME}
+	 */
+	private String taskServiceAccountName = DEFAULT_TASK_SERVICE_ACCOUNT_NAME;
+
+	/**
+	 * Obtains the {@link RestartPolicy} to use. Defaults to
+	 * {@link #restartPolicy}.
+	 *
+	 * @return the {@link RestartPolicy} to use
+	 */
+	public RestartPolicy getRestartPolicy() {
+		return restartPolicy;
+	}
+
+	/**
+	 * Sets the {@link RestartPolicy} to use.
+	 *
+	 * @param restartPolicy the {@link RestartPolicy} to use
+	 */
+	public void setRestartPolicy(RestartPolicy restartPolicy) {
+		this.restartPolicy = restartPolicy;
+	}
+
+	/**
+	 * Obtains the service account name to use for tasks.
+	 *
+	 * @return the service account name
+	 */
+	public String getTaskServiceAccountName() {
+		return taskServiceAccountName;
+	}
+
+	/**
+	 * Sets the service account name to use for tasks.
+	 *
+	 * @param taskServiceAccountName the service account name
+	 */
+	public void setTaskServiceAccountName(String taskServiceAccountName) {
+		this.taskServiceAccountName = taskServiceAccountName;
+	}
+
+	/**
 	 * Name of the environment variable that can define the Kubernetes namespace to use.
 	 */
 	public static final String ENV_KEY_KUBERNETES_NAMESPACE = "KUBERNETES_NAMESPACE";

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesSchedulerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesSchedulerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Chris Schaefer
  */
+@Deprecated
 @ConfigurationProperties(prefix = KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX)
 public class KubernetesSchedulerProperties extends KubernetesDeployerProperties {
 	/**

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -423,7 +423,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 		String restartPolicyString =
 				PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
 						"spring.cloud.deployer.kubernetes.restartPolicy");
-		RestartPolicy restartPolicy =  (StringUtils.isEmpty(restartPolicyString)) ? this.taskLauncherProperties.getRestartPolicy() :
+		RestartPolicy restartPolicy =  (!StringUtils.hasText(restartPolicyString)) ? this.taskLauncherProperties.getRestartPolicy() :
 				RestartPolicy.valueOf(restartPolicyString);
 		if (this.properties.isCreateJob()) {
 			Assert.isTrue(!restartPolicy.equals(RestartPolicy.Always), "RestartPolicy should not be 'Always' when the JobSpec is used.");

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolverTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolverTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+
+/**
+ * Test the {@link DeploymentPropertiesResolver} class
+ * @author Glenn Renfro
+ */
+public class DeploymentPropertiesResolverTests {
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testRestartPolicy(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		DeploymentPropertiesResolver deploymentPropertiesResolver = getDeploymentPropertiesResolver(isDeprecated, kubernetesDeployerProperties);
+		Map<String, String> properties = new HashMap<>();
+		RestartPolicy restartPolicy = deploymentPropertiesResolver.getRestartPolicy(properties);
+		Assertions.assertThat(restartPolicy).isEqualTo(RestartPolicy.Always);
+		if (isDeprecated) {
+			properties.put(KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX + ".restartPolicy", RestartPolicy.Never.name());
+		}
+		else {
+			properties.put(KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX + ".restartPolicy", RestartPolicy.Never.name());
+		}
+		restartPolicy = deploymentPropertiesResolver.getRestartPolicy(properties);
+		Assertions.assertThat(restartPolicy).isEqualTo(RestartPolicy.Never);
+
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testTaskServiceAccountName(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		DeploymentPropertiesResolver deploymentPropertiesResolver = getDeploymentPropertiesResolver(isDeprecated, kubernetesDeployerProperties);
+		Map<String, String> properties = new HashMap<>();
+		String taskServiceAccountName = deploymentPropertiesResolver.getTaskServiceAccountName(properties);
+		Assertions.assertThat(taskServiceAccountName).isNull();
+		if (isDeprecated) {
+			properties.put(KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX + ".taskServiceAccountName", "FOO");
+		}
+		else {
+			properties.put(KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX + ".taskServiceAccountName", "FOO");
+		}
+		taskServiceAccountName = deploymentPropertiesResolver.getTaskServiceAccountName(properties);
+		Assertions.assertThat(taskServiceAccountName).isEqualTo("FOO");
+
+	}
+
+	private DeploymentPropertiesResolver getDeploymentPropertiesResolver(boolean isDeprecated, KubernetesDeployerProperties properties) {
+		String propertiesPrefix = (isDeprecated) ? KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX :
+				KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX;
+		return new DeploymentPropertiesResolver(propertiesPrefix, properties);
+	}
+}

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerPropertiesTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerPropertiesTests.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2021-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.deployer.spi.kubernetes;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.util.StringUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link KubernetesDeployerProperties}.
+ *
+ * @author Glenn Renfro
+ */
+public class KubernetesDeployerPropertiesTests {
+
+	@Test
+	public void testImagePullPolicyDefault() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		assertNotNull("Image pull policy should not be null", kubernetesDeployerProperties.getImagePullPolicy());
+		assertEquals("Invalid default image pull policy", ImagePullPolicy.IfNotPresent,
+				kubernetesDeployerProperties.getImagePullPolicy());
+	}
+
+	@Test
+	public void testImagePullPolicyCanBeCustomized() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setImagePullPolicy(ImagePullPolicy.Never);
+		assertNotNull("Image pull policy should not be null", kubernetesDeployerProperties.getImagePullPolicy());
+		assertEquals("Unexpected image pull policy", ImagePullPolicy.Never,
+				kubernetesDeployerProperties.getImagePullPolicy());
+	}
+
+	@Test
+	public void testRestartPolicyDefault() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		assertNotNull("Restart policy should not be null", kubernetesDeployerProperties.getRestartPolicy());
+		assertEquals("Invalid default restart policy", RestartPolicy.Never,
+				kubernetesDeployerProperties.getRestartPolicy());
+	}
+
+	@Test
+	public void testRestartPolicyCanBeCustomized() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setRestartPolicy(RestartPolicy.OnFailure);
+		assertNotNull("Restart policy should not be null", kubernetesDeployerProperties.getRestartPolicy());
+		assertEquals("Unexpected restart policy", RestartPolicy.OnFailure,
+				kubernetesDeployerProperties.getRestartPolicy());
+	}
+
+	@Test
+	public void testEntryPointStyleDefault() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		assertNotNull("Entry point style should not be null", kubernetesDeployerProperties.getEntryPointStyle());
+		assertEquals("Invalid default entry point style", EntryPointStyle.exec,
+				kubernetesDeployerProperties.getEntryPointStyle());
+	}
+
+	@Test
+	public void testEntryPointStyleCanBeCustomized() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setEntryPointStyle(EntryPointStyle.shell);
+		assertNotNull("Entry point style should not be null", kubernetesDeployerProperties.getEntryPointStyle());
+		assertEquals("Unexpected entry point stype", EntryPointStyle.shell,
+				kubernetesDeployerProperties.getEntryPointStyle());
+	}
+
+	@Test
+	public void testNamespaceDefault() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
+
+			assertTrue("Namespace should not be empty or null",
+					StringUtils.hasText(kubernetesDeployerProperties.getNamespace()));
+			assertEquals("Invalid default namespace", "default", kubernetesDeployerProperties.getNamespace());
+		}
+	}
+
+	@Test
+	public void testNamespaceCanBeCustomized() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setNamespace("myns");
+		assertTrue("Namespace should not be empty or null",
+				StringUtils.hasText(kubernetesDeployerProperties.getNamespace()));
+		assertEquals("Unexpected namespace", "myns", kubernetesDeployerProperties.getNamespace());
+	}
+
+	@Test
+	public void testImagePullSecretDefault() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		assertNull("No default image pull secret should be set", kubernetesDeployerProperties.getImagePullSecret());
+	}
+
+	@Test
+	public void testImagePullSecretCanBeCustomized() {
+		String secret = "mysecret";
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setImagePullSecret(secret);
+		assertNotNull("Image pull secret should not be null", kubernetesDeployerProperties.getImagePullSecret());
+		assertEquals("Unexpected image pull secret", secret, kubernetesDeployerProperties.getImagePullSecret());
+	}
+
+	@Test
+	public void testEnvironmentVariablesDefault() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		assertEquals("No default environment variables should be set", 0,
+				kubernetesDeployerProperties.getEnvironmentVariables().length);
+	}
+
+	@Test
+	public void testEnvironmentVariablesCanBeCustomized() {
+		String[] envVars = new String[] { "var1=val1", "var2=val2" };
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setEnvironmentVariables(envVars);
+		assertNotNull("Environment variables should not be null",
+				kubernetesDeployerProperties.getEnvironmentVariables());
+		assertEquals("Unexpected number of environment variables", 2,
+				kubernetesDeployerProperties.getEnvironmentVariables().length);
+	}
+
+	@Test
+	public void testTaskServiceAccountNameDefault() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		assertNotNull("Task service account name should not be null",
+				kubernetesDeployerProperties.getTaskServiceAccountName());
+		assertEquals("Unexpected default task service account name",
+				kubernetesDeployerProperties.DEFAULT_TASK_SERVICE_ACCOUNT_NAME,
+				kubernetesDeployerProperties.getTaskServiceAccountName());
+	}
+
+	@Test
+	public void testTaskServiceAccountNameCanBeCustomized() {
+		String taskServiceAccountName = "mysa";
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setTaskServiceAccountName(taskServiceAccountName);
+		assertNotNull("Task service account name should not be null",
+				kubernetesDeployerProperties.getTaskServiceAccountName());
+		assertEquals("Unexpected task service account name", taskServiceAccountName,
+				kubernetesDeployerProperties.getTaskServiceAccountName());
+	}
+}

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesSchedulerIT.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesSchedulerIT.java
@@ -47,6 +47,8 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -108,7 +110,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 
 	@Override
 	protected Map<String, String> getDeploymentProperties() {
-		return null;
+		return Collections.singletonMap(SchedulerPropertyKeys.CRON_EXPRESSION, "57 13 ? * *");
 	}
 
 	@Override
@@ -143,20 +145,26 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		super.testListFilter();
 	}
 
-	@Test
-	public void testMissingSchedule() {
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testMissingSchedule(boolean isDeprecated) {
 		AppDefinition appDefinition = new AppDefinition(randomName(), null);
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, null, null, null, null, testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated)?
+				new ScheduleRequest(appDefinition, null, null, null, null, testApplication()) :
+				new ScheduleRequest(appDefinition, null, (List<String>) null, null, testApplication());
 
 		assertThatThrownBy(() -> {
 			scheduler.schedule(scheduleRequest);
 		}).isInstanceOf(CreateScheduleException.class);
 	}
 
-	@Test
-	public void testInvalidNameSchedule() {
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testInvalidNameSchedule(boolean isDeprecated) {
 		AppDefinition appDefinition = new AppDefinition("AAAAAA", null);
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, null, null, null, "AAAAA", testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ?
+				new ScheduleRequest(appDefinition, null, null, null, "AAAAA", testApplication()) :
+				new ScheduleRequest(appDefinition, null,(List<String>) null, "AAAAA", testApplication());
 
 		assertThatThrownBy(() -> {
 			scheduler.schedule(scheduleRequest);
@@ -179,11 +187,11 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		Map<String, String> mergedProperties = KubernetesScheduler.mergeSchedulerProperties(scheduleRequest);
 
 		assertThat(mergedProperties
-				.get(KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX + ".imagePullPolicy"))
+				.get(KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX + ".imagePullPolicy"))
 						.as("Expected value from Scheduler properties, but found in Deployer properties")
 						.isEqualTo("Never");
 		assertThat(mergedProperties
-				.get(KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX + ".environmentVariables"))
+				.get(KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX + ".environmentVariables"))
 						.as("Deployer property is expected to be merged as scheduler property")
 						.isEqualTo("MYVAR1=MYVAL1,MYVAR2=MYVAL2");
 	}
@@ -234,56 +242,61 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		assertThat(scheduleInfos.get(0).getScheduleName().equals("job1"));
 	}
 
-	@Test
-	public void testInvalidCronSyntax() {
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testInvalidCronSyntax(boolean isDeprecated) {
 		Map<String, String> schedulerProperties = Collections.singletonMap(SchedulerPropertyKeys.CRON_EXPRESSION, "1 2 3 4");
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), null);
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, schedulerProperties, null, null,
-				randomName(), testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, schedulerProperties, null, null, randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, schedulerProperties, (List<String>) null, randomName(), testApplication());
 
 		assertThatThrownBy(() -> {
 			scheduler.schedule(scheduleRequest);
 		}).isInstanceOf(CreateScheduleException.class);
 	}
 
-	@Test
-	public void testNameTooLong() {
-		final String baseScheduleName = "tencharlng-scdf-itcouldbesaidthatthisislongtoowaytoo";
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testNameTooLong(boolean isDeprecated) {
+		final String baseScheduleName = (isDeprecated) ? "tencharlng-scdf-itcouldbesaidthatthisislongtoowayold" :
+				"tencharlng-scdf-itcouldbesaidthatthisislongtoowaytoo";
 		Map<String, String> schedulerProperties = Collections.singletonMap(SchedulerPropertyKeys.CRON_EXPRESSION, "0/10 * * * *");
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), null);
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, schedulerProperties, null, null,
-				baseScheduleName, testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, schedulerProperties, null, null, baseScheduleName, testApplication()) :
+				new ScheduleRequest(appDefinition, schedulerProperties, (List<String>) null, baseScheduleName, testApplication());
 
 		//verify no validation fired.
 		scheduler.schedule(scheduleRequest);
 
-		ScheduleRequest scheduleRequest2 = new ScheduleRequest(appDefinition, schedulerProperties, null, null,
-				baseScheduleName + "1", testApplication());
+		ScheduleRequest scheduleRequest2 = (isDeprecated) ? new ScheduleRequest(appDefinition, schedulerProperties, null, null, baseScheduleName + "1", testApplication()) :
+				new ScheduleRequest(appDefinition, schedulerProperties, (List<String>) null, baseScheduleName + "1", testApplication());
 		assertThatThrownBy(() -> {
 			scheduler.schedule(scheduleRequest2);
 		}).isInstanceOf(CreateScheduleException.class)
 			.hasMessage(String.format("Failed to create schedule because Schedule Name: '%s' has too many characters.  Schedule name length must be 52 characters or less", baseScheduleName + "1"));
 	}
 
-	@Test
-	public void testWithExecEntryPoint() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testWithExecEntryPoint(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+				new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
-		kubernetesSchedulerProperties.setEntryPointStyle(EntryPointStyle.exec);
+		kubernetesDeployerProperties.setEntryPointStyle(EntryPointStyle.exec);
 
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(), null,
-				getCommandLineArgs(), randomName(), testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, getSchedulerProperties(), null, getCommandLineArgs(), randomName(), testApplication()):
+				new ScheduleRequest(appDefinition, getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
@@ -297,24 +310,25 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testWithShellEntryPoint() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testWithShellEntryPoint(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
-		kubernetesSchedulerProperties.setEntryPointStyle(EntryPointStyle.shell);
+		kubernetesDeployerProperties.setEntryPointStyle(EntryPointStyle.shell);
 
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(), null,
-				getCommandLineArgs(), randomName(), testApplication());
-
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, getSchedulerProperties(), null, getCommandLineArgs(), randomName(), testApplication()):
+				new ScheduleRequest(appDefinition, getSchedulerProperties(), getCommandLineArgs(), randomName(), testApplication());
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
 
@@ -329,23 +343,24 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testWithBootEntryPoint() throws IOException {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		kubernetesSchedulerProperties.setEntryPointStyle(EntryPointStyle.boot);
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testWithBootEntryPoint(boolean isDeprecated) throws IOException {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setEntryPointStyle(EntryPointStyle.boot);
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(), null,
-				getCommandLineArgs(), randomName(), testApplication());
-
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, getSchedulerProperties(), null, getCommandLineArgs(), randomName(), testApplication()):
+				new ScheduleRequest(appDefinition, getSchedulerProperties(), getCommandLineArgs(), randomName(), testApplication());
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
 
@@ -406,17 +421,19 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		assertThat(message).as("Field message should be null").isNull();
 	}
 
-	@Test
-	public void testEntryPointStyleOverride() throws Exception {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testEntryPointStyleOverride(boolean isDeprecated) throws Exception {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		String prefix = KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX;
 
@@ -424,8 +441,8 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		schedulerProperties.put(prefix + ".entryPointStyle", "boot");
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, schedulerProperties,
-				null, getCommandLineArgs(), randomName(), testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, schedulerProperties, null, getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, schedulerProperties, getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
@@ -446,21 +463,23 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testEntryPointStyleDefault() throws Exception {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testEntryPointStyleDefault(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
-				getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, getSchedulerProperties(), Collections.emptyMap(), getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
@@ -473,17 +492,19 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testImagePullPolicyOverride() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testImagePullPolicyOverride(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		String prefix = KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX;
 
@@ -491,8 +512,8 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		schedulerProperties.put(prefix + ".imagePullPolicy", "Always");
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, schedulerProperties,
-				null, getCommandLineArgs(), randomName(), testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, schedulerProperties, null, getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, schedulerProperties, getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
@@ -504,24 +525,26 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testJobAnnotationsAndLabelsFromSchedulerProperties() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		kubernetesSchedulerProperties.setJobAnnotations("test1:value1");
-		kubernetesSchedulerProperties.setPodAnnotations("podtest1:podvalue1");
-		kubernetesSchedulerProperties.setDeploymentLabels("label1:value1,label2:value2");
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testJobAnnotationsAndLabelsFromSchedulerProperties(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setJobAnnotations("test1:value1");
+		kubernetesDeployerProperties.setPodAnnotations("podtest1:podvalue1");
+		kubernetesDeployerProperties.setDeploymentLabels("label1:value1,label2:value2");
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
-				null, getCommandLineArgs(), randomName(), testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, getSchedulerProperties(), null, getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, getSchedulerProperties(), getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 
@@ -535,15 +558,15 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 
 	@Test
 	public void testDefaultLabel() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
 		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
@@ -558,29 +581,36 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testJobAnnotationsAndLabelsFromSchedulerRequest() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		kubernetesSchedulerProperties.setJobAnnotations("test1:value1");
-		kubernetesSchedulerProperties.setPodAnnotations("podtest1:podvalue1");
-		kubernetesSchedulerProperties.setDeploymentLabels("label1:value1,label2:value2");
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testJobAnnotationsAndLabelsFromSchedulerRequest(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setJobAnnotations("test1:value1");
+		kubernetesDeployerProperties.setPodAnnotations("podtest1:podvalue1");
+		kubernetesDeployerProperties.setDeploymentLabels("label1:value1,label2:value2");
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
 		Map<String, String> scheduleProperties = new HashMap<>();
 		scheduleProperties.putAll(getSchedulerProperties());
-		scheduleProperties.put("spring.cloud.scheduler.kubernetes.deploymentLabels", "requestLabel1:requestValue1,requestLabel2:requestValue2");
-		scheduleProperties.put("spring.cloud.scheduler.kubernetes.podAnnotations", "requestPod1:requestPodValue1");
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, scheduleProperties,
-				null, getCommandLineArgs(), randomName(), testApplication());
-
+		if(isDeprecated) {
+			scheduleProperties.put("spring.cloud.scheduler.kubernetes.deploymentLabels", "requestLabel1:requestValue1,requestLabel2:requestValue2");
+			scheduleProperties.put("spring.cloud.scheduler.kubernetes.podAnnotations", "requestPod1:requestPodValue1");
+		}
+		else {
+			scheduleProperties.put("spring.cloud.deployer.kubernetes.deploymentLabels", "requestLabel1:requestValue1,requestLabel2:requestValue2");
+			scheduleProperties.put("spring.cloud.deployer.kubernetes.podAnnotations", "requestPod1:requestPodValue1");
+		}
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, scheduleProperties, null, getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, scheduleProperties, getCommandLineArgs(), randomName(), testApplication());
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 
 		assertThat(cronJob.getMetadata().getAnnotations().get("test1")).as("Job annotation is not set").isEqualTo("value1");
@@ -595,26 +625,28 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testJobAnnotationsOverride() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		kubernetesSchedulerProperties.setJobAnnotations("test1:value1");
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testJobAnnotationsOverride(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		kubernetesDeployerProperties.setJobAnnotations("test1:value1");
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
 		String prefix = KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX;
 		Map<String, String> schedulerProperties = new HashMap<>(getSchedulerProperties());
 		schedulerProperties.put(prefix + ".jobAnnotations", "test1:value2");
 
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, schedulerProperties,
-				null, getCommandLineArgs(), randomName(), testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, schedulerProperties, null, getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, schedulerProperties, getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 
@@ -623,22 +655,23 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testImagePullPolicyDefault() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testImagePullPolicyDefault(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
-				getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
-
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, getSchedulerProperties(), Collections.emptyMap(), getCommandLineArgs(), randomName(), testApplication()) :
+			new ScheduleRequest(appDefinition, getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
 
@@ -649,17 +682,19 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testImagePullSecret() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testImagePullSecret(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		String secretName = "mysecret";
 		String prefix = KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX;
@@ -668,9 +703,8 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		schedulerProperties.put(prefix + ".imagePullSecret", secretName);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, schedulerProperties,
-				null, getCommandLineArgs(), randomName(), testApplication());
-
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, schedulerProperties, null, getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, schedulerProperties, getCommandLineArgs(), randomName(), testApplication());
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
 
@@ -681,21 +715,23 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testImagePullSecretDefault() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testImagePullSecretDefault(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
-				getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, getSchedulerProperties(), Collections.emptyMap(), getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
@@ -707,24 +743,26 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testImagePullSecretFromSchedulerProperties() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testImagePullSecretFromSchedulerProperties(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 
 		String secretName = "image-secret";
-		kubernetesSchedulerProperties.setImagePullSecret(secretName);
+		kubernetesDeployerProperties.setImagePullSecret(secretName);
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
-				getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, getSchedulerProperties(), Collections.emptyMap(), getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
@@ -736,9 +774,11 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testCustomEnvironmentVariables() {
-		String prefix = KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX;
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testCustomEnvironmentVariables(boolean isDeprecated) {
+		String prefix = (isDeprecated) ? KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX :
+				KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX;
 
 		Map<String, String> schedulerProperties = new HashMap<>(getSchedulerProperties());
 		schedulerProperties.put(prefix + ".environmentVariables", "MYVAR1=MYVAL1,MYVAR2=MYVAL2");
@@ -746,26 +786,30 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		EnvVar[] expectedVars = new EnvVar[] { new EnvVar("MYVAR1", "MYVAL1", null),
 				new EnvVar("MYVAR2", "MYVAL2", null) };
 
-		testEnvironmentVariables(new KubernetesSchedulerProperties(), schedulerProperties, expectedVars);
+		testEnvironmentVariables(new KubernetesDeployerProperties(), schedulerProperties, expectedVars, isDeprecated);
 	}
 
-	@Test
-	public void testGlobalEnvironmentVariables() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testGlobalEnvironmentVariables(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
-		kubernetesSchedulerProperties.setEnvironmentVariables(new String[] { "MYVAR1=MYVAL1" ,"MYVAR2=MYVAL2" });
+		kubernetesDeployerProperties.setEnvironmentVariables(new String[] { "MYVAR1=MYVAL1" ,"MYVAR2=MYVAL2" });
 
 		EnvVar[] expectedVars = new EnvVar[] { new EnvVar("MYVAR1", "MYVAL1", null),
 				new EnvVar("MYVAR2", "MYVAL2", null) };
 
-		testEnvironmentVariables(kubernetesSchedulerProperties, getSchedulerProperties(), expectedVars);
+		testEnvironmentVariables(kubernetesDeployerProperties, getSchedulerProperties(), expectedVars, isDeprecated);
 	}
 
-	@Test
-	public void testCustomEnvironmentVariablesWithNestedComma() {
-		String prefix = KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX;
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testCustomEnvironmentVariablesWithNestedComma(boolean isDeprecated) {
+		String prefix = (isDeprecated) ? KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX :
+				KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX;
 
 		Map<String, String> schedulerProperties = new HashMap<>(getSchedulerProperties());
 		schedulerProperties.put(prefix + ".environmentVariables", "MYVAR='VAL1,VAL2',MYVAR2=MYVAL2");
@@ -773,18 +817,22 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		EnvVar[] expectedVars = new EnvVar[] { new EnvVar("MYVAR", "VAL1,VAL2", null),
 				new EnvVar("MYVAR2", "MYVAL2", null) };
 
-		testEnvironmentVariables(new KubernetesSchedulerProperties(), schedulerProperties, expectedVars);
+		testEnvironmentVariables((isDeprecated) ? new KubernetesSchedulerProperties() : new KubernetesDeployerProperties(), schedulerProperties, expectedVars, isDeprecated);
 	}
 
-	@Test
-	public void testGlobalAndCustomEnvironmentVariables() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
-		}
-		kubernetesSchedulerProperties.setEnvironmentVariables(new String[] { "MYVAR1=MYVAL1","MYVAR2=MYVAL2" });
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testGlobalAndCustomEnvironmentVariables(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
 
-		String prefix = KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX;
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
+		}
+		kubernetesDeployerProperties.setEnvironmentVariables(new String[] { "MYVAR1=MYVAL1","MYVAR2=MYVAL2" });
+
+		String prefix = (isDeprecated) ? KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX :
+				KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX;
 
 		Map<String, String> schedulerProperties = new HashMap<>(getSchedulerProperties());
 		schedulerProperties.put(prefix + ".environmentVariables", "MYVAR3=MYVAL3,MYVAR4=MYVAL4");
@@ -793,18 +841,21 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 				new EnvVar("MYVAR2", "MYVAL2", null), new EnvVar("MYVAR3", "MYVAL3", null),
 				new EnvVar("MYVAR4", "MYVAL4", null) };
 
-		testEnvironmentVariables(kubernetesSchedulerProperties, schedulerProperties, expectedVars);
+		testEnvironmentVariables(kubernetesDeployerProperties, schedulerProperties, expectedVars, isDeprecated);
 	}
 
-	@Test
-	public void testCustomEnvironmentVariablesOverrideGlobal() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testCustomEnvironmentVariablesOverrideGlobal(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
-		kubernetesSchedulerProperties.setEnvironmentVariables(new String[] { "MYVAR1=MYVAL1", "MYVAR2=MYVAL2" });
+		kubernetesDeployerProperties.setEnvironmentVariables(new String[] { "MYVAR1=MYVAL1", "MYVAR2=MYVAL2" });
 
-		String prefix = KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX;
+		String prefix = (isDeprecated) ? KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX :
+				KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX;
 
 		Map<String, String> schedulerProperties = new HashMap<>(getSchedulerProperties());
 		schedulerProperties.put(prefix + ".environmentVariables", "MYVAR2=OVERRIDE");
@@ -812,24 +863,23 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		EnvVar[] expectedVars = new EnvVar[] { new EnvVar("MYVAR1", "MYVAL1", null),
 				new EnvVar("MYVAR2", "OVERRIDE", null) };
 
-		testEnvironmentVariables(kubernetesSchedulerProperties, schedulerProperties, expectedVars);
+		testEnvironmentVariables(kubernetesDeployerProperties, schedulerProperties, expectedVars, isDeprecated);
 	}
 
-	private void testEnvironmentVariables(KubernetesSchedulerProperties kubernetesSchedulerProperties,
-			Map<String, String> schedulerProperties, EnvVar[] expectedVars) {
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	private void testEnvironmentVariables(KubernetesDeployerProperties kubernetesDeployerProperties,
+			Map<String, String> schedulerProperties, EnvVar[] expectedVars, boolean isDeprecated) {
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, schedulerProperties,
-				null, getCommandLineArgs(), randomName(), testApplication());
-
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, schedulerProperties, null, getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, schedulerProperties,getCommandLineArgs(), randomName(), testApplication());
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
 
@@ -842,17 +892,19 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testTaskServiceAccountNameOverride() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testTaskServiceAccountNameOverride(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		String taskServiceAccountName = "mysa";
 		String prefix = KubernetesSchedulerProperties.KUBERNETES_SCHEDULER_PROPERTIES_PREFIX;
@@ -874,21 +926,25 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
-	@Test
-	public void testTaskServiceAccountNameDefault() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
-		if (kubernetesSchedulerProperties.getNamespace() == null) {
-			kubernetesSchedulerProperties.setNamespace("default");
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testTaskServiceAccountNameDefault(boolean isDeprecated) {
+		KubernetesDeployerProperties kubernetesDeployerProperties =
+						new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
 		}
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace());
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
-		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
-				getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
+		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, getSchedulerProperties(),
+				getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication()) :
+				new ScheduleRequest(appDefinition, getDeploymentProperties(),
+						getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
@@ -902,14 +958,14 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 
 	@AfterAll
 	public static void cleanup() {
-		KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
 
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesSchedulerProperties.getNamespace() != null
-						? kubernetesSchedulerProperties.getNamespace() : "default");
+				.inNamespace(kubernetesDeployerProperties.getNamespace() != null
+						? kubernetesDeployerProperties.getNamespace() : "default");
 
 		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
-				kubernetesSchedulerProperties);
+				kubernetesDeployerProperties);
 
 		List<ScheduleInfo> scheduleInfos = kubernetesScheduler.list();
 
@@ -925,20 +981,20 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@EnableAutoConfiguration
 	@EnableConfigurationProperties
 	public static class Config {
-		private KubernetesSchedulerProperties kubernetesSchedulerProperties = new KubernetesSchedulerProperties();
+		private KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
 
 		@Bean
 		public Scheduler scheduler(KubernetesClient kubernetesClient) {
-			return new KubernetesScheduler(kubernetesClient, kubernetesSchedulerProperties);
+			return new KubernetesScheduler(kubernetesClient, kubernetesDeployerProperties);
 		}
 
 		@Bean
 		public KubernetesClient kubernetesClient() {
-			if (kubernetesSchedulerProperties.getNamespace() == null) {
-				kubernetesSchedulerProperties.setNamespace("default");
+			if (kubernetesDeployerProperties.getNamespace() == null) {
+				kubernetesDeployerProperties.setNamespace("default");
 			}
 
-			return KubernetesClientFactory.getKubernetesClient(kubernetesSchedulerProperties);
+			return KubernetesClientFactory.getKubernetesClient(kubernetesDeployerProperties);
 		}
 	}
 }


### PR DESCRIPTION
Deprecate the use of scheduler properties.   All scheduling properties should come from deployment properties.
Child of https://github.com/spring-cloud/spring-cloud-dataflow/issues/4262
Resolves SCDK-456