### PR TITLE
Add Supplemental Groups to Pod Security Context.

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.AffinityBuilder;
@@ -415,6 +416,7 @@ class DeploymentPropertiesResolver {
 			podSecurityContext = new PodSecurityContextBuilder()
 					.withRunAsUser(deployerProperties.getPodSecurityContext().getRunAsUser())
 					.withFsGroup(deployerProperties.getPodSecurityContext().getFsGroup())
+					.withSupplementalGroups(deployerProperties.getPodSecurityContext().getSupplementalGroups())
 					.build();
 		}
 		else {
@@ -424,16 +426,21 @@ class DeploymentPropertiesResolver {
 			String fsGroup = PropertyParserUtils.getDeploymentPropertyValue(kubernetesDeployerProperties,
 					this.propertyPrefix + ".podSecurityContext.fsGroup");
 
-			if (StringUtils.hasText(runAsUser) && StringUtils.hasText(fsGroup)) {
+			String supplementalGroups = PropertyParserUtils.getDeploymentPropertyValue(kubernetesDeployerProperties,
+					this.propertyPrefix + ".podSecurityContext.supplementalGroups");
+
+			if (StringUtils.hasText(runAsUser) && StringUtils.hasText(fsGroup) && StringUtils.hasText(supplementalGroups)) {
 				podSecurityContext = new PodSecurityContextBuilder()
 						.withRunAsUser(Long.valueOf(runAsUser))
 						.withFsGroup(Long.valueOf(fsGroup))
+						.withSupplementalGroups(Stream.of(supplementalGroups.split(",")).map(Long::valueOf).collect(Collectors.toList()))
 						.build();
 			}
 			else if (this.properties.getPodSecurityContext() != null) {
 				podSecurityContext = new PodSecurityContextBuilder()
 						.withRunAsUser(this.properties.getPodSecurityContext().getRunAsUser())
 						.withFsGroup(this.properties.getPodSecurityContext().getFsGroup())
+						.withSupplementalGroups(this.properties.getPodSecurityContext().getSupplementalGroups())
 						.build();
 			}
 		}

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
@@ -433,7 +433,7 @@ class DeploymentPropertiesResolver {
 				podSecurityContext = new PodSecurityContextBuilder()
 						.withRunAsUser(Long.valueOf(runAsUser))
 						.withFsGroup(Long.valueOf(fsGroup))
-						.withSupplementalGroups(Stream.of(supplementalGroups.split(",")).map(Long::valueOf).collect(Collectors.toList()))
+						.withSupplementalGroups(Stream.of(supplementalGroups.replaceAll("\\[|\\]", "").split(",")).map(Long::valueOf).collect(Collectors.toList()))
 						.build();
 			}
 			else if (this.properties.getPodSecurityContext() != null) {

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -340,6 +340,8 @@ public class KubernetesDeployerProperties {
 
 		private Long fsGroup;
 
+		private Long[] supplementalGroups;
+
 		public void setRunAsUser(Long runAsUser) {
 			this.runAsUser = runAsUser;
 		}
@@ -354,6 +356,14 @@ public class KubernetesDeployerProperties {
 
 		public Long getFsGroup() {
 			return fsGroup;
+		}
+
+		public void setSupplementalGroups(Long[] supplementalGroups) {
+			this.supplementalGroups = supplementalGroups;
+		}
+
+		public Long[] getSupplementalGroups(){
+			return supplementalGroups;
 		}
 	}
 

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -825,7 +825,7 @@ public class KubernetesAppDeployerTests {
 	@Test
 	public void testPodSecurityContextProperty() {
 		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534}");
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535]}");
 
 		AppDefinition definition = new AppDefinition("app-test", null);
 		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
@@ -839,6 +839,7 @@ public class KubernetesAppDeployerTests {
 
 		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
 		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
 	}
 
 	@Test
@@ -953,6 +954,7 @@ public class KubernetesAppDeployerTests {
 		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
 		securityContext.setFsGroup(65534L);
 		securityContext.setRunAsUser(65534L);
+		securityContext.setSupplementalGroups(new Long[]{65534L});
 
 		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
 
@@ -965,6 +967,7 @@ public class KubernetesAppDeployerTests {
 
 		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
 		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L}));
 	}
 
 	@Test
@@ -1101,6 +1104,7 @@ public class KubernetesAppDeployerTests {
 
 		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
 		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+        assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
 	}
 
 	@Test
@@ -1162,6 +1166,7 @@ public class KubernetesAppDeployerTests {
 
 		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
 		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
 	}
 
 	@Test
@@ -1181,12 +1186,33 @@ public class KubernetesAppDeployerTests {
 
 		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
 		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+        assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
 	}
+
+    @Test
+    public void testPodSecurityContextSupplementalGroupsOnly() {
+        Map<String, String> props = new HashMap<>();
+        props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
+
+        AppDefinition definition = new AppDefinition("app-test", null);
+        AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+        deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+        PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+        PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+        assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+        assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
+        assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
+        assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L }));
+    }
 
 	@Test
 	public void testPodSecurityContextPropertyOverrideGlobal() {
 		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534}");
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535]}");
 
 		AppDefinition definition = new AppDefinition("app-test", null);
 		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
@@ -1196,6 +1222,7 @@ public class KubernetesAppDeployerTests {
 		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
 		securityContext.setFsGroup(1000L);
 		securityContext.setRunAsUser(1000L);
+		securityContext.setSupplementalGroups(new Long[]{1000L});
 
 		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
 
@@ -1208,6 +1235,7 @@ public class KubernetesAppDeployerTests {
 
 		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
 		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
 	}
 
 	@Test

--- a/src/test/resources/dataflow-server-podsecuritycontext.yml
+++ b/src/test/resources/dataflow-server-podsecuritycontext.yml
@@ -2,3 +2,4 @@
 podSecurityContext:
   runAsUser: 65534
   fsGroup: 65534
+  supplementalGroups: [65534,65535]


### PR DESCRIPTION
Supplemental Groups which controls group IDs containers will be a new feature for pod security context.