### PR TITLE
Add support for seccompProfile on pod security context and configuring container security context.

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -34,6 +34,7 @@ import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -60,6 +61,7 @@ import org.springframework.util.StringUtils;
  * @author Chris Schaefer
  * @author Enrique Medina Montenegro
  * @author Ilayaperumal Gopinathan
+ * @author Chris Bono
  */
 public class AbstractKubernetesDeployer {
 
@@ -250,6 +252,12 @@ public class AbstractKubernetesDeployer {
 		if (hostNetwork) {
 			podSpec.withHostNetwork(true);
 		}
+
+		SecurityContext containerSecurityContext = this.deploymentPropertiesResolver.getContainerSecurityContext(deploymentProperties);
+		if (containerSecurityContext != null) {
+			container.setSecurityContext(containerSecurityContext);
+		}
+
 		podSpec.addToContainers(container);
 
 		podSpec.withRestartPolicy(this.deploymentPropertiesResolver.getRestartPolicy(deploymentProperties).name());

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -38,6 +38,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * @author Chris Schaefer
  * @author David Turanski
  * @author Enrique Medina Montenegro
+ * @author Chris Bono
  */
 @ConfigurationProperties(prefix = KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX)
 public class KubernetesDeployerProperties {
@@ -336,11 +337,25 @@ public class KubernetesDeployerProperties {
 	}
 
 	public static class PodSecurityContext {
+		/**
+		 * The numeric user ID to run pod container processes under
+		 */
 		private Long runAsUser;
 
+		/**
+		 * The numeric group ID for the volumes of the pod
+		 */
 		private Long fsGroup;
 
+		/**
+		 * The numeric group IDs applied to the pod container processes, in addition to the container's primary group ID
+		 */
 		private Long[] supplementalGroups;
+
+		/**
+		 * The seccomp options to use for the pod containers
+		 */
+		private SeccompProfile seccompProfile;
 
 		public void setRunAsUser(Long runAsUser) {
 			this.runAsUser = runAsUser;
@@ -364,6 +379,74 @@ public class KubernetesDeployerProperties {
 
 		public Long[] getSupplementalGroups(){
 			return supplementalGroups;
+		}
+
+		public SeccompProfile getSeccompProfile() {
+			return seccompProfile;
+		}
+
+		public void setSeccompProfile(SeccompProfile seccompProfile) {
+			this.seccompProfile = seccompProfile;
+		}
+	}
+
+	/**
+	 * Defines a pod seccomp profile settings.
+	 */
+	public static class SeccompProfile {
+
+		/**
+		 * Type of seccomp profile.
+		 */
+		private String type;
+
+		/**
+		 * Path of the pre-configured profile on the node, relative to the kubelet's configured Seccomp profile location, only valid when type is "Localhost".
+		 */
+		private String localhostProfile;
+
+		public String getType() {
+			return type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		public String getLocalhostProfile() {
+			return localhostProfile;
+		}
+
+		public void setLocalhostProfile(String localhostProfile) {
+			this.localhostProfile = localhostProfile;
+		}
+	}
+
+	public static class ContainerSecurityContext {
+		/**
+		 * Whether a process can gain more privileges than its parent process
+		 */
+		private Boolean allowPrivilegeEscalation;
+
+		/**
+		 * Mounts the container's root filesystem as read-only
+		 */
+		private Boolean readOnlyRootFilesystem;
+
+		public void setAllowPrivilegeEscalation(Boolean allowPrivilegeEscalation) {
+			this.allowPrivilegeEscalation = allowPrivilegeEscalation;
+		}
+
+		public Boolean getAllowPrivilegeEscalation() {
+			return allowPrivilegeEscalation;
+		}
+
+		public void setReadOnlyRootFilesystem(Boolean readOnlyRootFilesystem) {
+			this.readOnlyRootFilesystem = readOnlyRootFilesystem;
+		}
+
+		public Boolean getReadOnlyRootFilesystem() {
+			return readOnlyRootFilesystem;
 		}
 	}
 
@@ -822,6 +905,11 @@ public class KubernetesDeployerProperties {
 	 * The security context to apply to created pod's.
 	 */
 	private PodSecurityContext podSecurityContext;
+
+	/**
+	 * The security context to apply to created pod's main container.
+	 */
+	private ContainerSecurityContext containerSecurityContext;
 
 	/**
 	 * The node affinity rules to apply.
@@ -1446,6 +1534,14 @@ public class KubernetesDeployerProperties {
 
 	public PodSecurityContext getPodSecurityContext() {
 		return podSecurityContext;
+	}
+
+	public void setContainerSecurityContext(ContainerSecurityContext containerSecurityContext) {
+		this.containerSecurityContext = containerSecurityContext;
+	}
+
+	public ContainerSecurityContext getContainerSecurityContext() {
+		return containerSecurityContext;
 	}
 
 	public NodeAffinity getNodeAffinity() {

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -1248,108 +1248,6 @@ public class KubernetesAppDeployerTests {
 		assertThat(podAntiAffinityTest.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
 	}
 
-	@Nested
-	@DisplayName("creates pod spec with container security context")
-	class CreatePodSpecWithContainerSecurityContext {
-
-		@Test
-		@DisplayName("created from deployment property with all fields")
-		void createdFromDeploymentPropertyWithAllFields() {
-			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-			Map<String, String> deploymentProps = Collections.singletonMap("spring.cloud.deployer.kubernetes.containerSecurityContext", "{allowPrivilegeEscalation: false, readOnlyRootFilesystem: true}");
-			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
-					.withAllowPrivilegeEscalation(false)
-					.withReadOnlyRootFilesystem(true)
-					.build();
-			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
-		}
-
-		@Test
-		@DisplayName("created from deployment property with allowPrivilegeEscalation only")
-		void createdFromDeploymentPropertyWithAllowPrivilegeEscalationOnly() {
-			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-			Map<String, String> deploymentProps = Collections.singletonMap("spring.cloud.deployer.kubernetes.containerSecurityContext", "{allowPrivilegeEscalation: true}");
-			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
-					.withAllowPrivilegeEscalation(true)
-					.build();
-			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
-		}
-
-		@Test
-		@DisplayName("created from deployment property with readOnlyRootFilesystem only")
-		void createdFromDeploymentPropertyWithReadOnlyRootFilesystemOnly() {
-			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-			Map<String, String> deploymentProps = Collections.singletonMap("spring.cloud.deployer.kubernetes.containerSecurityContext", "{readOnlyRootFilesystem: true}");
-			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
-					.withReadOnlyRootFilesystem(true)
-					.build();
-			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
-		}
-
-		@Test
-		@DisplayName("created from global deployer property sourced from yaml")
-		void createdFromGlobalDeployerPropertySourcedFromYaml() throws Exception {
-			KubernetesDeployerProperties globalDeployerProps = bindDeployerProperties();
-			Map<String, String> deploymentProps = Collections.emptyMap();
-			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
-					.withAllowPrivilegeEscalation(true)
-					.withReadOnlyRootFilesystem(false)
-					.build();
-			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
-		}
-
-		@Test
-		@DisplayName("created from global deployer property")
-		void createdFromGlobalDeployerProperty() {
-			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-			KubernetesDeployerProperties.ContainerSecurityContext securityContext = new KubernetesDeployerProperties.ContainerSecurityContext();
-			securityContext.setAllowPrivilegeEscalation(false);
-			securityContext.setReadOnlyRootFilesystem(true);
-			globalDeployerProps.setContainerSecurityContext(securityContext);
-			Map<String, String> deploymentProps = Collections.emptyMap();
-			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
-					.withAllowPrivilegeEscalation(false)
-					.withReadOnlyRootFilesystem(true)
-					.build();
-			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
-		}
-
-		@Test
-		@DisplayName("created from deployment property overrriding global deployer property")
-		void createdFromDeploymentPropertyOverridingGlobalDeployerProperty() {
-			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-			KubernetesDeployerProperties.ContainerSecurityContext securityContext = new KubernetesDeployerProperties.ContainerSecurityContext();
-			securityContext.setAllowPrivilegeEscalation(true);
-			securityContext.setReadOnlyRootFilesystem(false);
-			globalDeployerProps.setContainerSecurityContext(securityContext);
-			Map<String, String> deploymentProps = Collections.singletonMap("spring.cloud.deployer.kubernetes.containerSecurityContext", "{allowPrivilegeEscalation: false, readOnlyRootFilesystem: true}");
-			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
-					.withAllowPrivilegeEscalation(false)
-					.withReadOnlyRootFilesystem(true)
-					.build();
-			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
-		}
-
-		private void assertThatDeployerCreatesPodSpecWithContainerSecurityContext(
-				KubernetesDeployerProperties globalDeployerProps,
-				Map<String, String> deploymentProps,
-				SecurityContext expectedContainerSecurityContext
-		) {
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-			assertThat(podSpec.getContainers())
-					.singleElement()
-					.extracting(Container::getSecurityContext)
-					.isEqualTo(expectedContainerSecurityContext);
-		}
-
-		private PodSpec deployerCreatesPodSpec(KubernetesDeployerProperties globalDeployerProperties, Map<String, String> deploymentProperties) {
-			AppDefinition definition = new AppDefinition("app-test", null);
-			AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), deploymentProperties);
-			KubernetesAppDeployer deployer = new KubernetesAppDeployer(globalDeployerProperties, null);
-			return deployer.createPodSpec(appDeploymentRequest);
-		}
-	}
-
 	@Nested 
 	@DisplayName("creates pod spec with pod security context")
 	class CreatePodSpecWithPodSecurityContext {
@@ -1489,13 +1387,108 @@ public class KubernetesAppDeployerTests {
 					.isNotNull()
 					.isEqualTo(expectedPodSecurityContext);
 		}
+	}
 
-		private PodSpec deployerCreatesPodSpec(KubernetesDeployerProperties globalDeployerProperties, Map<String, String> deploymentProperties) {
-			AppDefinition definition = new AppDefinition("app-test", null);
-			AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), deploymentProperties);
-			KubernetesAppDeployer deployer = new KubernetesAppDeployer(globalDeployerProperties, null);
-			return deployer.createPodSpec(appDeploymentRequest);
+	@Nested
+	@DisplayName("creates pod spec with container security context")
+	class CreatePodSpecWithContainerSecurityContext {
+
+		@Test
+		@DisplayName("created from deployment property with all fields")
+		void createdFromDeploymentPropertyWithAllFields() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = Collections.singletonMap("spring.cloud.deployer.kubernetes.containerSecurityContext", "{allowPrivilegeEscalation: false, readOnlyRootFilesystem: true}");
+			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
+					.withAllowPrivilegeEscalation(false)
+					.withReadOnlyRootFilesystem(true)
+					.build();
+			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
 		}
+
+		@Test
+		@DisplayName("created from deployment property with allowPrivilegeEscalation only")
+		void createdFromDeploymentPropertyWithAllowPrivilegeEscalationOnly() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = Collections.singletonMap("spring.cloud.deployer.kubernetes.containerSecurityContext", "{allowPrivilegeEscalation: true}");
+			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
+					.withAllowPrivilegeEscalation(true)
+					.build();
+			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
+		}
+
+		@Test
+		@DisplayName("created from deployment property with readOnlyRootFilesystem only")
+		void createdFromDeploymentPropertyWithReadOnlyRootFilesystemOnly() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = Collections.singletonMap("spring.cloud.deployer.kubernetes.containerSecurityContext", "{readOnlyRootFilesystem: true}");
+			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
+					.withReadOnlyRootFilesystem(true)
+					.build();
+			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
+		}
+
+		@Test
+		@DisplayName("created from global deployer property sourced from yaml")
+		void createdFromGlobalDeployerPropertySourcedFromYaml() throws Exception {
+			KubernetesDeployerProperties globalDeployerProps = bindDeployerProperties();
+			Map<String, String> deploymentProps = Collections.emptyMap();
+			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
+					.withAllowPrivilegeEscalation(true)
+					.withReadOnlyRootFilesystem(false)
+					.build();
+			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
+		}
+
+		@Test
+		@DisplayName("created from global deployer property")
+		void createdFromGlobalDeployerProperty() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			KubernetesDeployerProperties.ContainerSecurityContext securityContext = new KubernetesDeployerProperties.ContainerSecurityContext();
+			securityContext.setAllowPrivilegeEscalation(false);
+			securityContext.setReadOnlyRootFilesystem(true);
+			globalDeployerProps.setContainerSecurityContext(securityContext);
+			Map<String, String> deploymentProps = Collections.emptyMap();
+			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
+					.withAllowPrivilegeEscalation(false)
+					.withReadOnlyRootFilesystem(true)
+					.build();
+			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
+		}
+
+		@Test
+		@DisplayName("created from deployment property overrriding global deployer property")
+		void createdFromDeploymentPropertyOverridingGlobalDeployerProperty() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			KubernetesDeployerProperties.ContainerSecurityContext securityContext = new KubernetesDeployerProperties.ContainerSecurityContext();
+			securityContext.setAllowPrivilegeEscalation(true);
+			securityContext.setReadOnlyRootFilesystem(false);
+			globalDeployerProps.setContainerSecurityContext(securityContext);
+			Map<String, String> deploymentProps = Collections.singletonMap("spring.cloud.deployer.kubernetes.containerSecurityContext", "{allowPrivilegeEscalation: false, readOnlyRootFilesystem: true}");
+			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
+					.withAllowPrivilegeEscalation(false)
+					.withReadOnlyRootFilesystem(true)
+					.build();
+			assertThatDeployerCreatesPodSpecWithContainerSecurityContext(globalDeployerProps, deploymentProps, expectedContainerSecurityContext);
+		}
+
+		private void assertThatDeployerCreatesPodSpecWithContainerSecurityContext(
+				KubernetesDeployerProperties globalDeployerProps,
+				Map<String, String> deploymentProps,
+				SecurityContext expectedContainerSecurityContext
+		) {
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+			assertThat(podSpec.getContainers())
+					.singleElement()
+					.extracting(Container::getSecurityContext)
+					.isEqualTo(expectedContainerSecurityContext);
+		}
+	}
+
+	private PodSpec deployerCreatesPodSpec(KubernetesDeployerProperties globalDeployerProperties, Map<String, String> deploymentProperties) {
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), deploymentProperties);
+		KubernetesAppDeployer deployer = new KubernetesAppDeployer(globalDeployerProperties, null);
+		return deployer.createPodSpec(appDeploymentRequest);
 	}
 
 	@Test

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -1350,179 +1350,188 @@ public class KubernetesAppDeployerTests {
 		}
 	}
 
-	@Test
-	public void testPodSecurityContextPropertyAllFields() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: RuntimeDefault }}");
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withRunAsUser(65534L)
-				.withFsGroup(65534L)
-				.withSupplementalGroups(65534L, 65535L)
-				.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertyUIDOnly() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534}");
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withRunAsUser(65534L)
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertyFsGroupOnly() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{fsGroup: 65534}");
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withFsGroup(65534L)
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertySupplementalGroupsOnly() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withSupplementalGroups(65534L, 65535L)
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertySeccompProfileOnly() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{seccompProfile: { type: RuntimeDefault}}");
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertyFromYaml() throws Exception {
-		KubernetesDeployerProperties globalDeployerProps = bindDeployerProperties();
-		Map<String, String> deploymentProps = new HashMap<>();
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withRunAsUser(65534L)
-				.withFsGroup(65534L)
-				.withSupplementalGroups(65534L, 65535L)
-				.withSeccompProfile(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"))
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextGlobalProperty() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
-		securityContext.setFsGroup(65534L);
-		securityContext.setRunAsUser(65534L);
-		securityContext.setSupplementalGroups(new Long[]{65534L});
-		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
-		seccompProfile.setType("Localhost");
-		seccompProfile.setLocalhostProfile("profile.json");
-		securityContext.setSeccompProfile(seccompProfile);
-		globalDeployerProps.setPodSecurityContext(securityContext);
-
-		Map<String, String> deploymentProps = Collections.emptyMap();
-
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withRunAsUser(65534L)
-				.withFsGroup(65534L)
-				.withSupplementalGroups(65534L)
-				.withSeccompProfile(new SeccompProfile("profile.json", "Localhost"))
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	@Test
-	public void testPodSecurityContextPropertyOverrideGlobal() {
-		KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
-		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
-		securityContext.setFsGroup(1000L);
-		securityContext.setRunAsUser(1000L);
-		securityContext.setSupplementalGroups(new Long[]{1000L});
-		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
-		seccompProfile.setType("Localhost");
-		seccompProfile.setLocalhostProfile("sec/default-allow.json");
-		securityContext.setSeccompProfile(seccompProfile);
-		globalDeployerProps.setPodSecurityContext(securityContext);
-
-		Map<String, String> deploymentProps = new HashMap<>();
-		deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534,65535], seccompProfile: { type: Localhost, localhostProfile: sec/custom-allow.json } }");
-
-		PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
-				.withRunAsUser(65534L)
-				.withFsGroup(65534L)
-				.withSupplementalGroups(65534L, 65535L)
-				.withSeccompProfile(new SeccompProfile("sec/custom-allow.json", "Localhost"))
-				.build();
-
-		PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-
-		PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-		assertThat(actualPodSecurityContext)
-				.isNotNull()
-				.isEqualTo(expectedPodSecurityContext);
-	}
-
-	private PodSpec deployerCreatesPodSpec(KubernetesDeployerProperties globalDeployerProperties, Map<String, String> deploymentProperties) {
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), deploymentProperties);
-		KubernetesAppDeployer deployer = new KubernetesAppDeployer(globalDeployerProperties, null);
-		return deployer.createPodSpec(appDeploymentRequest);
+	@Nested 
+	@DisplayName("creates pod spec with pod security context")
+	class CreatePodSpecWithPodSecurityContext {
+	
+		@Test
+		@DisplayName("created from deployment property with all fields")
+		void createdFromDeploymentPropertyWithAllFields() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: RuntimeDefault }}");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withRunAsUser(65534L)
+					.withFsGroup(65534L)
+					.withSupplementalGroups(65534L, 65535L)
+					.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from deployment property with runAsUser only")
+		void createdFromDeploymentPropertyWithRunAsUserOnly() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534}");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withRunAsUser(65534L)
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from deployment property with fsGroup only")
+		void createdFromDeploymentPropertyWithFsGroupOnly() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{fsGroup: 65534}");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withFsGroup(65534L)
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from deployment property with supplementalGroups only")
+		void createdFromDeploymentPropertyWithSupplementalGroupsOnly() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withSupplementalGroups(65534L, 65535L)
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from deployment property with seccompProfile only")
+		void createdFromDeploymentPropertyWithSeccompProfileOnly() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{seccompProfile: { type: RuntimeDefault}}");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from global deployer property sourced from yaml")
+		void createdFromGlobalDeployerPropertySourcedFromYaml() throws Exception {
+			KubernetesDeployerProperties globalDeployerProps = bindDeployerProperties();
+			Map<String, String> deploymentProps = new HashMap<>();
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withRunAsUser(65534L)
+					.withFsGroup(65534L)
+					.withSupplementalGroups(65534L, 65535L)
+					.withSeccompProfile(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"))
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from global deployer property")
+		void createdFromGlobalDeployerProperty() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
+			securityContext.setFsGroup(65534L);
+			securityContext.setRunAsUser(65534L);
+			securityContext.setSupplementalGroups(new Long[]{65534L});
+			KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
+			seccompProfile.setType("Localhost");
+			seccompProfile.setLocalhostProfile("profile.json");
+			securityContext.setSeccompProfile(seccompProfile);
+			globalDeployerProps.setPodSecurityContext(securityContext);
+			Map<String, String> deploymentProps = Collections.emptyMap();
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withRunAsUser(65534L)
+					.withFsGroup(65534L)
+					.withSupplementalGroups(65534L)
+					.withSeccompProfile(new SeccompProfile("profile.json", "Localhost"))
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		@Test
+		@DisplayName("created from deployment property overrriding global deployer property")
+		void createdFromDeploymentPropertyOverridingGlobalDeployerProperty() {
+			KubernetesDeployerProperties globalDeployerProps = new KubernetesDeployerProperties();
+			KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
+			securityContext.setFsGroup(1000L);
+			securityContext.setRunAsUser(1000L);
+			securityContext.setSupplementalGroups(new Long[]{1000L});
+			KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
+			seccompProfile.setType("Localhost");
+			seccompProfile.setLocalhostProfile("sec/default-allow.json");
+			securityContext.setSeccompProfile(seccompProfile);
+			globalDeployerProps.setPodSecurityContext(securityContext);
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534,65535], seccompProfile: { type: Localhost, localhostProfile: sec/custom-allow.json } }");
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withRunAsUser(65534L)
+					.withFsGroup(65534L)
+					.withSupplementalGroups(65534L, 65535L)
+					.withSeccompProfile(new SeccompProfile("sec/custom-allow.json", "Localhost"))
+					.build();
+	
+			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
+	
+			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
+			assertThat(actualPodSecurityContext)
+					.isNotNull()
+					.isEqualTo(expectedPodSecurityContext);
+		}
+	
+		private PodSpec deployerCreatesPodSpec(KubernetesDeployerProperties globalDeployerProperties, Map<String, String> deploymentProperties) {
+			AppDefinition definition = new AppDefinition("app-test", null);
+			AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), deploymentProperties);
+			KubernetesAppDeployer deployer = new KubernetesAppDeployer(globalDeployerProperties, null);
+			return deployer.createPodSpec(appDeploymentRequest);
+		}
 	}
 
 	@Test

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -1366,13 +1366,7 @@ public class KubernetesAppDeployerTests {
 					.withSupplementalGroups(65534L, 65535L)
 					.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1384,13 +1378,7 @@ public class KubernetesAppDeployerTests {
 			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
 					.withRunAsUser(65534L)
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1402,13 +1390,7 @@ public class KubernetesAppDeployerTests {
 			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
 					.withFsGroup(65534L)
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1420,13 +1402,7 @@ public class KubernetesAppDeployerTests {
 			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
 					.withSupplementalGroups(65534L, 65535L)
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1438,13 +1414,7 @@ public class KubernetesAppDeployerTests {
 			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
 					.withSeccompProfile(new SeccompProfile(null, "RuntimeDefault"))
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1458,13 +1428,7 @@ public class KubernetesAppDeployerTests {
 					.withSupplementalGroups(65534L, 65535L)
 					.withSeccompProfile(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"))
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1487,13 +1451,7 @@ public class KubernetesAppDeployerTests {
 					.withSupplementalGroups(65534L)
 					.withSeccompProfile(new SeccompProfile("profile.json", "Localhost"))
 					.build();
-	
-			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
-			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
-			assertThat(actualPodSecurityContext)
-					.isNotNull()
-					.isEqualTo(expectedPodSecurityContext);
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
 		}
 	
 		@Test
@@ -1517,15 +1475,21 @@ public class KubernetesAppDeployerTests {
 					.withSupplementalGroups(65534L, 65535L)
 					.withSeccompProfile(new SeccompProfile("sec/custom-allow.json", "Localhost"))
 					.build();
-	
+			assertThatDeployerCreatesPodSpecWithPodSecurityContext(globalDeployerProps, deploymentProps, expectedPodSecurityContext);
+		}
+
+		private void assertThatDeployerCreatesPodSpecWithPodSecurityContext(
+				KubernetesDeployerProperties globalDeployerProps,
+				Map<String, String> deploymentProps,
+				PodSecurityContext expectedPodSecurityContext
+		) {
 			PodSpec podSpec = deployerCreatesPodSpec(globalDeployerProps, deploymentProps);
-	
 			PodSecurityContext actualPodSecurityContext = podSpec.getSecurityContext();
 			assertThat(actualPodSecurityContext)
 					.isNotNull()
 					.isEqualTo(expectedPodSecurityContext);
 		}
-	
+
 		private PodSpec deployerCreatesPodSpec(KubernetesDeployerProperties globalDeployerProperties, Map<String, String> deploymentProperties) {
 			AppDefinition definition = new AppDefinition("app-test", null);
 			AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), deploymentProperties);

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerTests.java
@@ -831,27 +831,6 @@ public class KubernetesAppDeployerTests {
 	}
 
 	@Test
-	public void testPodSecurityContextProperty() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: RuntimeDefault }}");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile(null, "RuntimeDefault"));
-	}
-
-	@Test
 	public void testNodeAffinityProperty() {
 		Map<String, String> props = new HashMap<>();
 		props.put("spring.cloud.deployer.kubernetes.affinity.nodeAffinity",
@@ -951,38 +930,6 @@ public class KubernetesAppDeployerTests {
 		assertThat(podAntiAffinity).as("Pod anti-affinity should not be null").isNotNull();
 		assertThat(podAntiAffinity.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
 		assertThat(podAntiAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
-	}
-
-	@Test
-	public void testPodSecurityContextGlobalProperty() {
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
-
-		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
-
-		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
-		seccompProfile.setType("Localhost");
-		seccompProfile.setLocalhostProfile("profile.json");
-
-		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
-		securityContext.setFsGroup(65534L);
-		securityContext.setRunAsUser(65534L);
-		securityContext.setSupplementalGroups(new Long[]{65534L});
-		securityContext.setSeccompProfile(seccompProfile);
-
-		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
-
-		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile("profile.json", "Localhost"));
 	}
 
 	@Test
@@ -1106,24 +1053,6 @@ public class KubernetesAppDeployerTests {
 	}
 
 	@Test
-	public void testPodSecurityContextFromYaml() throws Exception {
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
-
-		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"));
-	}
-
-	@Test
 	public void testNodeAffinityFromYaml() throws Exception {
 		AppDefinition definition = new AppDefinition("app-test", null);
 		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
@@ -1163,128 +1092,6 @@ public class KubernetesAppDeployerTests {
 		assertThat(podAntiAffinity).as("Pod anti-affinity should not be null").isNotNull();
 		assertThat(podAntiAffinity.getRequiredDuringSchedulingIgnoredDuringExecution()).as("RequiredDuringSchedulingIgnoredDuringExecution should not be null").isNotNull();
 		assertThat(podAntiAffinity.getPreferredDuringSchedulingIgnoredDuringExecution().size()).as("PreferredDuringSchedulingIgnoredDuringExecution should have one element").isEqualTo(1);
-	}
-
-	@Test
-	public void testPodSecurityContextUIDOnly() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534}");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
-	}
-
-	@Test
-	public void testPodSecurityContextFsGroupOnly() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{fsGroup: 65534}");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
-	}
-
-    @Test
-    public void testPodSecurityContextSupplementalGroupsOnly() {
-        Map<String, String> props = new HashMap<>();
-        props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
-
-        AppDefinition definition = new AppDefinition("app-test", null);
-        AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-        deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-        PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-        PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-        assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-        assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
-        assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
-        assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L }));
-        assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
-    }
-
-	@Test
-	public void testPodSecurityContextSeccompProfileOnly() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{seccompProfile: { type: RuntimeDefault}}");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile")
-				.isEqualTo(new SeccompProfile(null, "RuntimeDefault"));
-	}
-
-	@Test
-	public void testPodSecurityContextPropertyOverrideGlobal() {
-		Map<String, String> props = new HashMap<>();
-		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534,65535], seccompProfile: { type: Localhost, localhostProfile: sec/custom-allow.json } }");
-
-		AppDefinition definition = new AppDefinition("app-test", null);
-		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
-
-		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
-
-		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
-		seccompProfile.setType("Localhost");
-		seccompProfile.setLocalhostProfile("sec/default-allow.json");
-
-		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
-		securityContext.setFsGroup(1000L);
-		securityContext.setRunAsUser(1000L);
-		securityContext.setSupplementalGroups(new Long[] {1000L});
-		securityContext.setSeccompProfile(seccompProfile);
-
-		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
-
-		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
-		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
-
-		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
-
-		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
-
-		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
-		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
-		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups")
-				.isEqualTo(Arrays.asList(new Long[] {65534L, 65535L}));
-		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile")
-				.isEqualTo(new SeccompProfile("sec/custom-allow.json", "Localhost"));
 	}
 
 	@Test
@@ -1544,6 +1351,199 @@ public class KubernetesAppDeployerTests {
 	}
 
 	@Test
+	public void testPodSecurityContextProperty() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534, 65535], seccompProfile: { type: RuntimeDefault }}");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile(null, "RuntimeDefault"));
+	}
+
+	@Test
+	public void testPodSecurityContextPropertyUIDOnly() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534}");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
+	}
+
+	@Test
+	public void testPodSecurityContextPropertyFsGroupOnly() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{fsGroup: 65534}");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
+	}
+
+	@Test
+	public void testPodSecurityContextPropertySupplementalGroupsOnly() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{supplementalGroups: [65534,65535]}");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L }));
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isNull();
+	}
+
+	@Test
+	public void testPodSecurityContextPropertySeccompProfileOnly() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{seccompProfile: { type: RuntimeDefault}}");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		deployer = new KubernetesAppDeployer(new KubernetesDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isNull();
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isNull();
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental group").isEmpty();
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile")
+				.isEqualTo(new SeccompProfile(null, "RuntimeDefault"));
+	}
+
+	@Test
+	public void testPodSecurityContextPropertyFromYaml() throws Exception {
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
+
+		deployer = new KubernetesAppDeployer(bindDeployerProperties(), null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L, 65535L}));
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile("my-profiles/profile-allow.json", "Localhost"));
+	}
+
+	@Test
+	public void testPodSecurityContextGlobalProperty() {
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), null);
+
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+
+		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
+		seccompProfile.setType("Localhost");
+		seccompProfile.setLocalhostProfile("profile.json");
+
+		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
+		securityContext.setFsGroup(65534L);
+		securityContext.setRunAsUser(65534L);
+		securityContext.setSupplementalGroups(new Long[]{65534L});
+		securityContext.setSeccompProfile(seccompProfile);
+
+		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
+
+		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups").isEqualTo(Arrays.asList(new Long[]{65534L}));
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile").isEqualTo(new SeccompProfile("profile.json", "Localhost"));
+	}
+
+	@Test
+	public void testPodSecurityContextPropertyOverrideGlobal() {
+		Map<String, String> props = new HashMap<>();
+		props.put("spring.cloud.deployer.kubernetes.podSecurityContext", "{runAsUser: 65534, fsGroup: 65534, supplementalGroups: [65534,65535], seccompProfile: { type: Localhost, localhostProfile: sec/custom-allow.json } }");
+
+		AppDefinition definition = new AppDefinition("app-test", null);
+		AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, getResource(), props);
+
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+
+		KubernetesDeployerProperties.SeccompProfile seccompProfile = new KubernetesDeployerProperties.SeccompProfile();
+		seccompProfile.setType("Localhost");
+		seccompProfile.setLocalhostProfile("sec/default-allow.json");
+
+		KubernetesDeployerProperties.PodSecurityContext securityContext = new KubernetesDeployerProperties.PodSecurityContext();
+		securityContext.setFsGroup(1000L);
+		securityContext.setRunAsUser(1000L);
+		securityContext.setSupplementalGroups(new Long[] {1000L});
+		securityContext.setSeccompProfile(seccompProfile);
+
+		kubernetesDeployerProperties.setPodSecurityContext(securityContext);
+
+		deployer = new KubernetesAppDeployer(kubernetesDeployerProperties, null);
+		PodSpec podSpec = deployer.createPodSpec(appDeploymentRequest);
+
+		PodSecurityContext podSecurityContext = podSpec.getSecurityContext();
+
+		assertThat(podSecurityContext).as("Pod security context should not be null").isNotNull();
+
+		assertThat(podSecurityContext.getRunAsUser()).as("Unexpected run as user").isEqualTo(65534);
+		assertThat(podSecurityContext.getFsGroup()).as("Unexpected fs group").isEqualTo(65534);
+		assertThat(podSecurityContext.getSupplementalGroups()).as("Unexpected supplemental groups")
+				.isEqualTo(Arrays.asList(new Long[] {65534L, 65535L}));
+		assertThat(podSecurityContext.getSeccompProfile()).as("Unexpected seccompProfile")
+				.isEqualTo(new SeccompProfile("sec/custom-allow.json", "Localhost"));
+	}
+
+	@Test
 	public void testWithLifecyclePostStart() {
 		Map<String, String> props = new HashMap<>();
 		props.put("spring.cloud.deployer.kubernetes.lifecycle.postStart.exec.command",
@@ -1612,7 +1612,6 @@ public class KubernetesAppDeployerTests {
 		assertThat(podSpec.getContainers().get(0).getLifecycle().getPreStop().getExec().getCommand())
 				.containsExactlyInAnyOrder("echo", "preStop");
 	}
-
 
 	@Test
 	public void testLifecyclePrestopOverridesGlobalPrestop() {

--- a/src/test/resources/dataflow-server-containerSecurityContext.yml
+++ b/src/test/resources/dataflow-server-containerSecurityContext.yml
@@ -1,0 +1,4 @@
+# spring.cloud.deployer.kubernetes.containerSecurityContext:
+containerSecurityContext:
+  allowPrivilegeEscalation: true
+  readOnlyRootFilesystem: false

--- a/src/test/resources/dataflow-server-podsecuritycontext.yml
+++ b/src/test/resources/dataflow-server-podsecuritycontext.yml
@@ -3,3 +3,6 @@ podSecurityContext:
   runAsUser: 65534
   fsGroup: 65534
   supplementalGroups: [65534,65535]
+  seccompProfile:
+    type: Localhost
+    localhostProfile: my-profiles/profile-allow.json


### PR DESCRIPTION
@ilayaperumalg 
~The motivating issue also [calls out](https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/issues/412#issuecomment-769017511) the need for container level `securityContext.(allowPrivilegeEscalation|readOnlyRootFilesystem)` support . However, I would prefer if we split that into another ticket (or at least an additional pull request) to keep the changes in this code proposal concise~

| ℹ️ Initially I was going to break this into 2 separate pull requests but decided to combine them once I saw them both implemented. |
| --- | 


### Adds support for configuring the seccompProfile on the pod security context

### Adds support for configuring the security context on the main container



- **Question 1:** I only apply the context to the main container. Should we add this to the initContainer as well? There is no need to do anything special for additional containers as the only mechanism to configure those is via full yaml - consumers can simply add the security context in that yaml if need be. 
- **Question 2:** Should we support more than these 2 requested properties? I know we do not support all available properties on the pod security context either. On one hand, adding more properties increases code to maintain. On the other hand, adding more properties gives users more options. 



### Refactors KubernetesAppDeployerTests as follows:
- Moved the pod and container security related tests into their own `@Nested` tests. 
- Simplified the assertions to use actual/expected object equality rather than individual property asserts
- I implemented the new container security context tests using the `@Nested` approach and it looked like a great fit for the existing pod security context tests as well. Because re-ordering and renaming code during a review makes for a not so fun review, I intentionally made small commits (2-6) to show step by step what I did w/ the pod security context tests to get to the final result. I apologize in advance for any grief this causes the reviewer. These of course should all be squashed into a single commit into main.

**Motivation:** 
The `KubernetesAppDeployerTests` has grown quite large and it is a challenge for a newbie (me) to grok all of whats going on in there. I leveraged `@Nested` to group the pod and container security context tests. I really love the output that `@Nested` produces in IntelliJ as well (see below)


<img width="1127" alt="nested-test-output" src="https://user-images.githubusercontent.com/28907971/146968529-21dc0b3f-2f11-4796-a2cb-c3e4fa4f460d.png">


- **Question 3:** I am curious to what the team thinks on this test as a whole. Should it be:
  - left as-is (don't use `@Nested`)?
  - split into separate `KubernetesAppDeployer<tested-area-goes-here>Tests`?
  - apply @Nessted to other areas of the test as well? 


### Remaining items 
- [ ] Finish updating the counterpart pull request to [spring-cloud-dataflow-docs](https://github.com/spring-cloud/spring-cloud-dataflow/pull/4784).

