### PR TITLE
Commas supported as values if quoted.

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/support/PropertyParserUtils.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/support/PropertyParserUtils.java
@@ -41,6 +41,10 @@ public class PropertyParserUtils {
 		Map<String, String> mapValue = new HashMap<>();
 
 		if (StringUtils.hasText(stringPairs)) {
+			/**
+			 * Positive look ahead that into a non capturing group that will skip all commas in quotes.
+			 * Even number quotes will be ignored by the non capturing group.
+			 */
 			String[] pairs = stringPairs.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
 			for (String pair : pairs) {
 				String[] splitString = pair.split(":", 2);

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/support/PropertyParserUtils.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/support/PropertyParserUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Chris Schaefer
  * @author Ilayaperumal Gopinathan
+ * @author Glenn Renfro
  */
 public class PropertyParserUtils {
 	/**
@@ -40,14 +41,14 @@ public class PropertyParserUtils {
 		Map<String, String> mapValue = new HashMap<>();
 
 		if (StringUtils.hasText(stringPairs)) {
-			String[] pairs = stringPairs.split(",");
+			String[] pairs = stringPairs.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
 			for (String pair : pairs) {
 				String[] splitString = pair.split(":", 2);
 				Assert.isTrue(splitString.length == 2, String.format("Invalid annotation value: %s", pair));
-				mapValue.put(splitString[0].trim(), splitString[1].trim());
+				String value = splitString[1].trim();
+				mapValue.put(splitString[0].trim(), value);
 			}
 		}
-
 		return mapValue;
 	}
 

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/PropertyParserUtilsTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/PropertyParserUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Chris Schaefer
  * @author Ilayaperumal Gopinathan
+ * @author Glenn Renfro
  */
 public class PropertyParserUtilsTests {
 
@@ -50,6 +51,42 @@ public class PropertyParserUtilsTests {
 		assertThat(annotations.size() == 2).isTrue();
 		assertThat(annotations.containsKey("annotation1")).isTrue();
 		assertThat(annotations.get("annotation1").equals("value1")).isTrue();
+		assertThat(annotations.containsKey("annotation2")).isTrue();
+		assertThat(annotations.get("annotation2").equals("value2")).isTrue();
+	}
+
+	@Test
+	public void testAnnotationParseMultipleWithCommas() {
+		Map<String, String> annotations = PropertyParserUtils.getStringPairsToMap("annotation1:\"value1,a,b,c,d\",annotation2:value2");
+		assertThat(annotations.isEmpty()).isFalse();
+		assertThat(annotations.size() == 2).isTrue();
+		assertThat(annotations.containsKey("annotation1")).isTrue();
+		assertThat(annotations.get("annotation1").equals("\"value1,a,b,c,d\"")).isTrue();
+		assertThat(annotations.containsKey("annotation2")).isTrue();
+		assertThat(annotations.get("annotation2").equals("value2")).isTrue();
+		annotations = PropertyParserUtils.getStringPairsToMap("annotation1:value1,annotation2:\"value2,a,b,c,d\"");
+		assertThat(annotations.isEmpty()).isFalse();
+		assertThat(annotations.size() == 2).isTrue();
+		assertThat(annotations.containsKey("annotation1")).isTrue();
+		assertThat(annotations.get("annotation1").equals("value1")).isTrue();
+		assertThat(annotations.containsKey("annotation2")).isTrue();
+		assertThat(annotations.get("annotation2").equals("\"value2,a,b,c,d\"")).isTrue();
+		annotations = PropertyParserUtils.getStringPairsToMap("annotation1:\"value1,a,b,c,d\",annotation2:\"value2,a,b,c,d\"");
+		assertThat(annotations.isEmpty()).isFalse();
+		assertThat(annotations.size() == 2).isTrue();
+		assertThat(annotations.containsKey("annotation1")).isTrue();
+		assertThat(annotations.get("annotation1").equals("\"value1,a,b,c,d\"")).isTrue();
+		assertThat(annotations.containsKey("annotation2")).isTrue();
+		assertThat(annotations.get("annotation2").equals("\"value2,a,b,c,d\"")).isTrue();
+	}
+
+	@Test
+	public void testAnnotationWithQuotes() {
+		Map<String, String> annotations = PropertyParserUtils.getStringPairsToMap("annotation1:\"value1\",annotation2:value2");
+		assertThat(annotations.isEmpty()).isFalse();
+		assertThat(annotations.size() == 2).isTrue();
+		assertThat(annotations.containsKey("annotation1")).isTrue();
+		assertThat(annotations.get("annotation1").equals("\"value1\"")).isTrue();
 		assertThat(annotations.containsKey("annotation2")).isTrue();
 		assertThat(annotations.get("annotation2").equals("value2")).isTrue();
 	}

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/PropertyParserUtilsTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/PropertyParserUtilsTests.java
@@ -57,27 +57,27 @@ public class PropertyParserUtilsTests {
 
 	@Test
 	public void testAnnotationParseMultipleWithCommas() {
-		Map<String, String> annotations = PropertyParserUtils.getStringPairsToMap("annotation1:\"value1,a,b,c,d\",annotation2:value2");
-		assertThat(annotations.isEmpty()).isFalse();
-		assertThat(annotations.size() == 2).isTrue();
-		assertThat(annotations.containsKey("annotation1")).isTrue();
-		assertThat(annotations.get("annotation1").equals("\"value1,a,b,c,d\"")).isTrue();
-		assertThat(annotations.containsKey("annotation2")).isTrue();
-		assertThat(annotations.get("annotation2").equals("value2")).isTrue();
-		annotations = PropertyParserUtils.getStringPairsToMap("annotation1:value1,annotation2:\"value2,a,b,c,d\"");
-		assertThat(annotations.isEmpty()).isFalse();
-		assertThat(annotations.size() == 2).isTrue();
-		assertThat(annotations.containsKey("annotation1")).isTrue();
-		assertThat(annotations.get("annotation1").equals("value1")).isTrue();
-		assertThat(annotations.containsKey("annotation2")).isTrue();
-		assertThat(annotations.get("annotation2").equals("\"value2,a,b,c,d\"")).isTrue();
-		annotations = PropertyParserUtils.getStringPairsToMap("annotation1:\"value1,a,b,c,d\",annotation2:\"value2,a,b,c,d\"");
-		assertThat(annotations.isEmpty()).isFalse();
-		assertThat(annotations.size() == 2).isTrue();
-		assertThat(annotations.containsKey("annotation1")).isTrue();
-		assertThat(annotations.get("annotation1").equals("\"value1,a,b,c,d\"")).isTrue();
-		assertThat(annotations.containsKey("annotation2")).isTrue();
-		assertThat(annotations.get("annotation2").equals("\"value2,a,b,c,d\"")).isTrue();
+		assertThat(PropertyParserUtils.getStringPairsToMap("annotation1:\"value1,a,b,c,d\",annotation2:value2"))
+				.isNotEmpty()
+				.hasSize(2)
+				.containsEntry("annotation1", "\"value1,a,b,c,d\"")
+				.containsEntry("annotation2", "value2");
+		assertThat(PropertyParserUtils.getStringPairsToMap("annotation1:value1,annotation2:\"value2,a,b,c,d\""))
+				.isNotEmpty()
+				.hasSize(2)
+				.containsEntry("annotation1", "value1")
+				.containsEntry("annotation2", "\"value2,a,b,c,d\"");
+		assertThat(PropertyParserUtils.getStringPairsToMap("annotation1:\"value1,a,b,c,d\",annotation2:\"value2,a,b,c,d\""))
+				.isNotEmpty()
+				.hasSize(2)
+				.containsEntry("annotation1", "\"value1,a,b,c,d\"")
+				.containsEntry("annotation2", "\"value2,a,b,c,d\"");
+// Test even number of quotes not to be used as token for ignoring commas boundary.
+		assertThat(PropertyParserUtils.getStringPairsToMap("annotation1:\"value1,a,b,\"\"c,d\",annotation2:\"value2,a,b,c,d\""))
+				.isNotEmpty()
+				.hasSize(2)
+				.containsEntry("annotation1", "\"value1,a,b,\"\"c,d\"")
+				.containsEntry("annotation2", "\"value2,a,b,c,d\"");
 	}
 
 	@Test


### PR DESCRIPTION
deployer.mytask.kubernetes.jobAnnotations now can contain commas in quoted strings.
resolves #479