### PR TITLE
Improve readability using stream chaining

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -55,6 +55,7 @@ import org.springframework.util.StringUtils;
  * @author Chris Schaefer
  * @author Ilayaperumal Gopinathan
  * @author Glenn Renfro
+ * @author Heechan Yang
  */
 public class DefaultContainerFactory implements ContainerFactory {
 	private static Log logger = LogFactory.getLog(DefaultContainerFactory.class);

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -276,8 +276,10 @@ public class DefaultContainerFactory implements ContainerFactory {
 		List<String> cmdArgs = new LinkedList<>();
 
 		List<String> commandArgOptions = request.getCommandlineArguments().stream()
-		.map(this::getArgOption)
-		.collect(Collectors.toList());
+				.filter(arg -> arg.contains("="))
+				.map(arg -> arg.split("=")[0])
+				.map(arg -> arg.trim().replaceAll("^--", ""))
+				.collect(Collectors.toList());
 
 		// add properties from deployment request
 		Map<String, String> args = request.getDefinition().getProperties();
@@ -301,12 +303,6 @@ public class DefaultContainerFactory implements ContainerFactory {
 		logger.debug("Using command args: " + cmdArgs);
 		return cmdArgs;
 	}
-
-	private String getArgOption(String arg) {
-		int indexOfAssignment = arg.indexOf("=");
-		String argOption = (indexOfAssignment < 0) ? arg : arg.substring(0, indexOfAssignment);
-		return argOption.trim().replaceAll("^--", "");
-	 }
 
 	private DeploymentPropertiesResolver getDeploymentPropertiesResolver(AppDeploymentRequest request) {
 		String propertiesPrefix = (request instanceof ScheduleRequest &&

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DefaultContainerFactory.java
@@ -275,7 +275,7 @@ public class DefaultContainerFactory implements ContainerFactory {
 	List<String> createCommandArgs(AppDeploymentRequest request) {
 		List<String> cmdArgs = new LinkedList<>();
 
-		List<String> commandArgOptions = request.getCommandlineArguments().stream()
+		List<String> keyValueTypeCommandArgs = request.getCommandlineArguments().stream()
 				.filter(arg -> arg.contains("="))
 				.map(arg -> arg.split("=")[0])
 				.map(arg -> arg.trim().replaceAll("^--", ""))
@@ -288,7 +288,7 @@ public class DefaultContainerFactory implements ContainerFactory {
 				logger.warn(
 						"Excluding request property with missing value from command args: " + entry.getKey());
 			}
-			else if (commandArgOptions.contains(entry.getKey())) {
+			else if (keyValueTypeCommandArgs.contains(entry.getKey())) {
 				logger.warn(
 						String.format(
 								"Excluding request property [--%s=%s] as a command arg. Existing command line argument takes precedence."


### PR DESCRIPTION
Thanks for resolving https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/pull/482 ! :D

I suggest a little refactoring for readability.
- name of variable `commandArgOptions`  -> `keyValueTypeCommandArgs`
- use stream chaining
  - filter only key-value type args
  - extract keys
  - trim and remove `--`

I checked the tests `testCommandLineArgsOverridesExistingProperties()`, `testCommandLineArgsExcludesMalformedProperties()`, `testCommandLineArgsNoAssignment()` in `DefaultContainerFactoryTests` were passed.

cc. @onobc @cppwfs 