### PR TITLE
Adds Minikube instructions back to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,29 @@ Build the project without running tests using:
 
 ## Integration tests
 
-All testing is curently done against a GKE cluster. Minikube is no longer useful since we test some parts of the external IP features that a LoadBalancer service provides.
+The integration tests require a running Kubernetes cluster. A couple of options are listed below.
+
+### Minkube
+[Minikube](https://github.com/kubernetes/minikube) is a tool that makes it easy to run Kubernetes locally. It runs a single-node Kubernetes cluster inside a VM on your laptop for users looking to try out Kubernetes or develop with it day-to-day. 
+
+Follow the [getting started](https://minikube.sigs.k8s.io/docs/start/) guide to install Minikube.
+
+1. Start Minikube
+   ```shell
+   minkube start
+   ```
+2. Run the tests
+   ```shell
+   ./mvnw clean test
+   ```
+3. Stop Minikube
+   ```shell
+   minkube stop
+   ```
+
 
 ### Google Container Engine
+While Minikube is very easy to run and test against, it is preferred to test against a GKE cluster. Minikube is not as useful since we test some parts of the external IP features that a LoadBalancer service provides.
 
 Create a test cluster and target it using something like (use your own project name, substitute --zone if needed):
 


### PR DESCRIPTION
I recently wanted to run the ITs locally and was unable to get GKE going again (I managed to beat it into submission and get it running sometime back, but then my trial expired etc..). So I figured I would try my luck running against Minikube, going against the advice in the README to use GKE.. 

> All testing is curently done against a GKE cluster. Minikube is no longer useful since we test some parts of the external IP features that a LoadBalancer service provides.

It worked fine. I then dug into the [ci-it.yml](https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/blob/c89dd43ba5b7210165ed1278caeaaba712d7bb05/.github/workflows/ci-it.yml#L25) to see what it was using for the ITs - it is also using Minikube?

I noticed that Minikube was replaced w/ GKE [way back in 2017](https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/commit/504cbf22c31cfba33348ea1ed94455406b2c1972). Is this something that has since been shifted back to using Minikube but yet to get reflected in the README?

My concern is that getting contributors to run the ITs against a GKE cluster may be quite a burden whereas Minikube is simple and painless. 


@jvalkeal @trisberg Thoughts? 