### PR TITLE
Add supporing of ttlSecondsAfterFinished configuration

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncher.java
@@ -261,6 +261,7 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 			JobSpec jobSpec = new JobSpecBuilder()
 					.withTemplate(podTemplateSpec)
 					.withBackoffLimit(getBackoffLimit(request))
+					.withTtlSecondsAfterFinished(getTtlSecondsAfterFinished(request))
 					.build();
 
 			this.client.batch().v1().jobs().create(
@@ -461,6 +462,23 @@ public class KubernetesTaskLauncher extends AbstractKubernetesDeployer implement
 		}
 		else {
 			return this.taskLauncherProperties.getBackoffLimit();
+		}
+	}
+
+	/**
+	 * Get the ttlSecondsAfterFinihsed setting for the deployment request.
+	 *
+	 * @param request The deployment request.
+	 * @return the ttlSecondsAfterFinished
+	 */
+	protected Integer getTtlSecondsAfterFinished(AppDeploymentRequest request) {
+		String ttlSecondsAfterFinished = PropertyParserUtils.getDeploymentPropertyValue(request.getDeploymentProperties(),
+				"spring.cloud.deployer.kubernetes.ttlSecondsAfterFinished");
+		if (StringUtils.hasText(ttlSecondsAfterFinished)) {
+			return Integer.valueOf(ttlSecondsAfterFinished);
+		}
+		else {
+			return this.taskLauncherProperties.getTtlSecondsAfterFinished();
 		}
 	}
 }

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesTaskLauncherProperties.java
@@ -36,6 +36,13 @@ public class KubernetesTaskLauncherProperties {
 	private Integer backoffLimit;
 
 	/**
+	 * The number of seconds after a job has finished before it is eligible to be automatically
+	 * removed by the TTL controller - note that logs from removed jobs will not be able to
+	 * be retrieved.
+	 */
+	private Integer ttlSecondsAfterFinished;
+
+	/**
 	 * Obtains the {@link RestartPolicy} to use. Defaults to
 	 * {@link KubernetesTaskLauncherProperties#restartPolicy}.
 	 *
@@ -69,5 +76,22 @@ public class KubernetesTaskLauncherProperties {
 	 */
 	public void setBackoffLimit(Integer backoffLimit) {
 		this.backoffLimit = backoffLimit;
+	}
+
+	/**
+	 * Get the ttlSecondsAfterFinished value
+	 * @return the integer value of ttlSecondsAfterFinished
+	 */
+	public Integer getTtlSecondsAfterFinished() {
+		return ttlSecondsAfterFinished;
+	}
+
+	/**
+	 * Sets the ttlSecondsAfterFinished.
+	 *
+	 * @param ttlSecondsAfterFinished the integer value of ttlSecondsAfterFinished
+	 */
+	public void setTtlSecondsAfterFinished(Integer ttlSecondsAfterFinished) {
+		this.ttlSecondsAfterFinished = ttlSecondsAfterFinished;
 	}
 }


### PR DESCRIPTION
This pull request is a proposal to add a supporting of automatic clean-up for finished jobs: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
 
*Changelog*:
 - Add supporting of ```ttlSecondsAfterFinished``` job spec. configuration
 - Test coverage