### PR TITLE
Adding shareProcessNamespace

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/AbstractKubernetesDeployer.java
@@ -285,6 +285,12 @@ public class AbstractKubernetesDeployer {
 		if (initContainer != null) {
 			podSpec.addToInitContainers(initContainer);
 		}
+
+		Boolean shareProcessNamespace = this.deploymentPropertiesResolver.getShareProcessNamespace(deploymentProperties);
+		if(shareProcessNamespace != null) {
+			podSpec.withShareProcessNamespace(shareProcessNamespace);
+		}
+
 		podSpec.addAllToContainers(this.deploymentPropertiesResolver.getAdditionalContainers(deploymentProperties));
 		return podSpec.build();
 	}

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/DeploymentPropertiesResolver.java
@@ -422,6 +422,12 @@ class DeploymentPropertiesResolver {
 		return podSecurityContext;
 	}
 
+	Boolean getShareProcessNamespace(Map<String, String> kubernetesDeployerProperties) {
+		KubernetesDeployerProperties deployerProperties = bindProperties(kubernetesDeployerProperties,
+			this.propertyPrefix + ".shareProcessNamespace", "shareProcessNamespace");
+		return deployerProperties.getShareProcessNamespace();
+	}
+
 	private PodSecurityContext buildPodSecurityContext(KubernetesDeployerProperties deployerProperties) {
 		PodSecurityContextBuilder podSecurityContextBuilder = new PodSecurityContextBuilder()
 				.withRunAsUser(deployerProperties.getPodSecurityContext().getRunAsUser())

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -690,6 +690,10 @@ public class KubernetesDeployerProperties {
     private String startupProbeScheme = "HTTP";
 
     /**
+     * If present will assign to spec.shareProcessNamespace of the Pod.
+     */
+    private Boolean shareProcessNamespace;
+    /**
      * Delay in seconds when the readiness check of the app container should start checking if
      * the module is fully up and running.
      */
@@ -1107,6 +1111,14 @@ public class KubernetesDeployerProperties {
 			this.concurrencyPolicy = concurrencyPolicy;
 		}
 	}
+
+    public Boolean getShareProcessNamespace() {
+        return shareProcessNamespace;
+    }
+
+    public void setShareProcessNamespace(Boolean shareProcessNamespace) {
+        this.shareProcessNamespace = shareProcessNamespace;
+    }
 
     /**
      * @deprecated @{see {@link #getLivenessHttpProbeDelay()}}

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/PropertyParserUtilsTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/PropertyParserUtilsTests.java
@@ -121,11 +121,13 @@ public class PropertyParserUtilsTests {
 		deploymentProps.put("spring.cloud.deployer.kubernetes.serviceAnnotations", "key3:value3,key4:value4");
 		deploymentProps.put("spring.cloud.deployer.kubernetes.init-container.image-name", "springcloud/openjdk");
 		deploymentProps.put("spring.cloud.deployer.kubernetes.initContainer.containerName", "test");
+		deploymentProps.put("spring.cloud.deployer.kubernetes.shareProcessNamespace", "true");
 		deploymentProps.put("spring.cloud.deployer.kubernetes.init-container.commands", "['sh','echo hello']");
 		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.podAnnotations").equals("key1:value1,key2:value2")).isTrue();
 		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.serviceAnnotations").equals("key3:value3,key4:value4")).isTrue();
 		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.initContainer.imageName").equals("springcloud/openjdk")).isTrue();
 		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.initContainer.imageName").equals("springcloud/openjdk")).isTrue();
 		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.imagePullPolicy").equals("Never")).isTrue();
+		assertThat(PropertyParserUtils.getDeploymentPropertyValue(deploymentProps, "spring.cloud.deployer.kubernetes.shareProcessNamespace").equals("true")).isTrue();
 	}
 }


### PR DESCRIPTION
Adding shareProcessNamespace to deployer properties for `Pod.spec.shareProcessNamespace`

Fixes #505 