### PR TITLE
Add security context to init containers

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -341,25 +341,57 @@ public class KubernetesDeployerProperties {
     }
 
     public static class PodSecurityContext {
-        /**
-         * The numeric user ID to run pod container processes under
-         */
-        private Long runAsUser;
+		/**
+		 * The numeric user ID to run pod container processes under
+		 */
+		private Long runAsUser;
+
+		/**
+		 * The numeric group id to run the entrypoint of the container process
+		 */
+		private Long runAsGroup;
+
+		/**
+		 * Indicates that the container must run as a non-root user
+		 */
+		private Boolean runAsNonRoot;
 
         /**
          * The numeric group ID for the volumes of the pod
          */
         private Long fsGroup;
 
+		/**
+		 * Defines behavior of changing ownership and permission of the volume before being
+		 * exposed inside pod (only applies to volume types which support fsGroup based
+		 * ownership and permissions) - possible values are "OnRootMismatch", "Always"
+		 */
+		private String fsGroupChangePolicy;
+
         /**
          * The numeric group IDs applied to the pod container processes, in addition to the container's primary group ID
          */
         private Long[] supplementalGroups;
 
-        /**
-         * The seccomp options to use for the pod containers
-         */
-        private SeccompProfile seccompProfile;
+		/**
+		 * The seccomp options to use for the pod containers
+		 */
+		private SeccompProfile seccompProfile;
+
+		/**
+		 * The SELinux context to be applied to the pod containers
+		 */
+		private SELinuxOptions seLinuxOptions;
+
+		/**
+		 * List of namespaced sysctls used for the pod (not used when spec.os.name is windows).
+		 */
+		private List<SysctlInfo> sysctls;
+
+		/**
+		 * The Windows specific settings applied to all containers.
+		 */
+		private WindowsSecurityContextOptions windowsOptions;
 
         public void setRunAsUser(Long runAsUser) {
             this.runAsUser = runAsUser;
@@ -369,7 +401,23 @@ public class KubernetesDeployerProperties {
             return this.runAsUser;
         }
 
-        public void setFsGroup(Long fsGroup) {
+		public Long getRunAsGroup() {
+			return runAsGroup;
+		}
+
+		public void setRunAsGroup(Long runAsGroup) {
+			this.runAsGroup = runAsGroup;
+		}
+
+		public Boolean getRunAsNonRoot() {
+			return runAsNonRoot;
+		}
+
+		public void setRunAsNonRoot(Boolean runAsNonRoot) {
+			this.runAsNonRoot = runAsNonRoot;
+		}
+
+		public void setFsGroup(Long fsGroup) {
             this.fsGroup = fsGroup;
         }
 
@@ -377,7 +425,15 @@ public class KubernetesDeployerProperties {
             return fsGroup;
         }
 
-        public void setSupplementalGroups(Long[] supplementalGroups) {
+		public String getFsGroupChangePolicy() {
+			return fsGroupChangePolicy;
+		}
+
+		public void setFsGroupChangePolicy(String fsGroupChangePolicy) {
+			this.fsGroupChangePolicy = fsGroupChangePolicy;
+		}
+
+		public void setSupplementalGroups(Long[] supplementalGroups) {
             this.supplementalGroups = supplementalGroups;
         }
 
@@ -392,12 +448,213 @@ public class KubernetesDeployerProperties {
         public void setSeccompProfile(SeccompProfile seccompProfile) {
             this.seccompProfile = seccompProfile;
         }
-    }
 
-    /**
+		public SELinuxOptions getSeLinuxOptions() {
+			return seLinuxOptions;
+		}
+
+		public void setSeLinuxOptions(SELinuxOptions seLinuxOptions) {
+			this.seLinuxOptions = seLinuxOptions;
+		}
+
+		public List<SysctlInfo> getSysctls() {
+			return sysctls;
+		}
+
+		public void setSysctls(List<SysctlInfo> sysctls) {
+			this.sysctls = sysctls;
+		}
+
+		public WindowsSecurityContextOptions getWindowsOptions() {
+			return windowsOptions;
+		}
+
+		public void setWindowsOptions(WindowsSecurityContextOptions windowsOptions) {
+			this.windowsOptions = windowsOptions;
+		}
+	}
+
+	public static class ContainerSecurityContext {
+
+		/**
+		 * Whether a process can gain more privileges than its parent process
+		 */
+		private Boolean allowPrivilegeEscalation;
+
+		/**
+		 * The capabilities to add/drop when running the container (cannot be set when spec.os.name is windows)
+		 */
+		private Capabilities capabilities;
+
+		/**
+		 * Run container in privileged mode.
+		 */
+		private Boolean privileged;
+
+		/**
+		 * The type of proc mount to use for the container (cannot be set when spec.os.name is windows)
+		 */
+		private String procMount;
+
+		/**
+		 * Mounts the container's root filesystem as read-only
+		 */
+		private Boolean readOnlyRootFilesystem;
+
+		/**
+		 * The numeric user ID to run pod container processes under
+		 */
+		private Long runAsUser;
+
+		/**
+		 * The numeric group id to run the entrypoint of the container process
+		 */
+		private Long runAsGroup;
+
+		/**
+		 * Indicates that the container must run as a non-root user
+		 */
+		private Boolean runAsNonRoot;
+
+		/**
+		 * The seccomp options to use for the container
+		 */
+		private SeccompProfile seccompProfile;
+
+		/**
+		 * The SELinux context to be applied to the container.
+		 */
+		private SELinuxOptions seLinuxOptions;
+
+		/**
+		 * The Windows specific settings applied to the container.
+		 */
+		private WindowsSecurityContextOptions windowsOptions;
+
+		public Boolean getAllowPrivilegeEscalation() {
+			return allowPrivilegeEscalation;
+		}
+
+		public void setAllowPrivilegeEscalation(Boolean allowPrivilegeEscalation) {
+			this.allowPrivilegeEscalation = allowPrivilegeEscalation;
+		}
+
+		public Capabilities getCapabilities() {
+			return capabilities;
+		}
+
+		public void setCapabilities(Capabilities capabilities) {
+			this.capabilities = capabilities;
+		}
+
+		public Boolean getPrivileged() {
+			return privileged;
+		}
+
+		public void setPrivileged(Boolean privileged) {
+			this.privileged = privileged;
+		}
+
+		public String getProcMount() {
+			return procMount;
+		}
+
+		public void setProcMount(String procMount) {
+			this.procMount = procMount;
+		}
+
+		public Boolean getReadOnlyRootFilesystem() {
+			return readOnlyRootFilesystem;
+		}
+
+		public void setReadOnlyRootFilesystem(Boolean readOnlyRootFilesystem) {
+			this.readOnlyRootFilesystem = readOnlyRootFilesystem;
+		}
+
+		public Long getRunAsUser() {
+			return runAsUser;
+		}
+
+		public void setRunAsUser(Long runAsUser) {
+			this.runAsUser = runAsUser;
+		}
+
+		public Long getRunAsGroup() {
+			return runAsGroup;
+		}
+
+		public void setRunAsGroup(Long runAsGroup) {
+			this.runAsGroup = runAsGroup;
+		}
+
+		public Boolean getRunAsNonRoot() {
+			return runAsNonRoot;
+		}
+
+		public void setRunAsNonRoot(Boolean runAsNonRoot) {
+			this.runAsNonRoot = runAsNonRoot;
+		}
+
+		public SeccompProfile getSeccompProfile() {
+			return seccompProfile;
+		}
+
+		public void setSeccompProfile(SeccompProfile seccompProfile) {
+			this.seccompProfile = seccompProfile;
+		}
+
+		public SELinuxOptions getSeLinuxOptions() {
+			return seLinuxOptions;
+		}
+
+		public void setSeLinuxOptions(SELinuxOptions seLinuxOptions) {
+			this.seLinuxOptions = seLinuxOptions;
+		}
+
+		public WindowsSecurityContextOptions getWindowsOptions() {
+			return windowsOptions;
+		}
+
+		public void setWindowsOptions(WindowsSecurityContextOptions windowsOptions) {
+			this.windowsOptions = windowsOptions;
+		}
+	}
+
+	/**
+	 * Adds and removes POSIX capabilities from running containers.
+	 */
+	public static class Capabilities {
+		/**
+		 * Added capabilities.
+		 */
+		private List<String> add;
+
+		/**
+		 * Removed capabilities.
+		 */
+		private List<String> drop;
+
+		public List<String> getAdd() {
+			return add;
+		}
+
+		public void setAdd(List<String> add) {
+			this.add = add;
+		}
+
+		public List<String> getDrop() {
+			return drop;
+		}
+
+		public void setDrop(List<String> drop) {
+			this.drop = drop;
+		}
+	}
+
+	/**
      * Defines a pod seccomp profile settings.
      */
-    public static class SeccompProfile {
+	public static class SeccompProfile {
 
         /**
          * Type of seccomp profile.
@@ -426,35 +683,154 @@ public class KubernetesDeployerProperties {
         }
     }
 
-    public static class ContainerSecurityContext {
-        /**
-         * Whether a process can gain more privileges than its parent process
-         */
-        private Boolean allowPrivilegeEscalation;
+	/**
+	 * The labels to be applied to the container.
+	 */
+	public static class SELinuxOptions {
+		/**
+		 * Level label applied to the container
+		 */
+		private String level;
 
-        /**
-         * Mounts the container's root filesystem as read-only
-         */
-        private Boolean readOnlyRootFilesystem;
+		/**
+		 * Role Level label applied to the container
+		 */
+		private String role;
 
-        public void setAllowPrivilegeEscalation(Boolean allowPrivilegeEscalation) {
-            this.allowPrivilegeEscalation = allowPrivilegeEscalation;
-        }
+		/**
+		 * Type label applied to the container
+		 */
+		private String type;
 
-        public Boolean getAllowPrivilegeEscalation() {
-            return allowPrivilegeEscalation;
-        }
+		/**
+		 * User label applied to the container
+		 */
+		private String user;
 
-        public void setReadOnlyRootFilesystem(Boolean readOnlyRootFilesystem) {
-            this.readOnlyRootFilesystem = readOnlyRootFilesystem;
-        }
+		public String getLevel() {
+			return level;
+		}
 
-        public Boolean getReadOnlyRootFilesystem() {
-            return readOnlyRootFilesystem;
-        }
-    }
+		public void setLevel(String level) {
+			this.level = level;
+		}
 
-    public static class Lifecycle {
+		public String getRole() {
+			return role;
+		}
+
+		public void setRole(String role) {
+			this.role = role;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		public String getUser() {
+			return user;
+		}
+
+		public void setUser(String user) {
+			this.user = user;
+		}
+	}
+
+	/**
+	 * Sysctl defines a kernel parameter to be set on the pod.
+	 */
+	public static class SysctlInfo {
+		/**
+		 * Name of the property
+		 */
+		private String name;
+
+		/**
+		 * Value of the property
+		 */
+		private String value;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+	}
+
+	/**
+	 * Contains Windows-specific options and credentials.
+	 */
+	public static class WindowsSecurityContextOptions {
+
+		/**
+		 * Where the GMSA admission webhook inlines the contents of the GMSA credential spec
+		 * named by the GMSACredentialSpecName field.
+		 */
+		private String gmsaCredentialSpec;
+
+		/**
+		 * The name of the GMSA credential spec to use.
+		 */
+		private String gmsaCredentialSpecName;
+
+		/**
+		 * Whether a container should be run as a 'Host Process' container.
+		 */
+		private Boolean hostProcess;
+
+		/**
+		 * The username in Windows to run the entrypoint of the container process.
+		 */
+		private String runAsUserName;
+
+		public String getGmsaCredentialSpec() {
+			return gmsaCredentialSpec;
+		}
+
+		public void setGmsaCredentialSpec(String gmsaCredentialSpec) {
+			this.gmsaCredentialSpec = gmsaCredentialSpec;
+		}
+
+		public String getGmsaCredentialSpecName() {
+			return gmsaCredentialSpecName;
+		}
+
+		public void setGmsaCredentialSpecName(String gmsaCredentialSpecName) {
+			this.gmsaCredentialSpecName = gmsaCredentialSpecName;
+		}
+
+		public Boolean getHostProcess() {
+			return hostProcess;
+		}
+
+		public void setHostProcess(Boolean hostProcess) {
+			this.hostProcess = hostProcess;
+		}
+
+		public String getRunAsUserName() {
+			return runAsUserName;
+		}
+
+		public void setRunAsUserName(String runAsUserName) {
+			this.runAsUserName = runAsUserName;
+		}
+	}
+
+	public static class Lifecycle {
         private Hook postStart;
         private Hook preStop;
 
@@ -500,7 +876,7 @@ public class KubernetesDeployerProperties {
         }
     }
 
-    public static class InitContainer extends ContainerProperties {
+	public static class InitContainer extends ContainerProperties {
     }
 
     static class Container extends io.fabric8.kubernetes.api.model.Container {

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationIT.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationIT.java
@@ -1679,7 +1679,7 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
     }
 
 	@Nested
-	class SecurityContextTests {
+	class SecurityContextITs {
 
 		@Test
 		void podWithInitContainerAndAdditionalContainers() {

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationIT.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesAppDeployerIntegrationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,13 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimSpec;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
+import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.SELinuxOptions;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecurityContext;
+import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
@@ -61,8 +66,10 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
@@ -102,6 +109,7 @@ import static org.mockito.Mockito.doAnswer;
  * @author David Turanski
  * @author Chris Schaefer
  * @author Christian Tzolov
+ * @author Chris Bono
  */
 @SpringBootTest(classes = {KubernetesAutoConfiguration.class}, properties = {
         "logging.level.org.springframework.cloud.deployer=DEBUG"
@@ -135,8 +143,8 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
         Resource resource = testApplication();
 
         Map<String, String> props = new HashMap<>();
-        props.put(KubernetesAppDeployer.COUNT_PROPERTY_KEY, "3");
-        props.put(KubernetesAppDeployer.INDEXED_PROPERTY_KEY, "true");
+        props.put(AppDeployer.COUNT_PROPERTY_KEY, "3");
+        props.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
 
         AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, props);
 
@@ -691,8 +699,8 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
     @Test
     public void testCreateStatefulSet() throws Exception {
         Map<String, String> props = new HashMap<>();
-        props.put(KubernetesAppDeployer.COUNT_PROPERTY_KEY, "3");
-        props.put(KubernetesAppDeployer.INDEXED_PROPERTY_KEY, "true");
+        props.put(AppDeployer.COUNT_PROPERTY_KEY, "3");
+        props.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
 
         AppDefinition definition = new AppDefinition(randomName(), null);
         AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, testApplication(), props);
@@ -724,6 +732,7 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
         assertThat(statefulSetInitContainers).hasSize(1);
         Container statefulSetInitContainer = statefulSetInitContainers.get(0);
         assertThat(statefulSetInitContainer.getImage()).isEqualTo(DeploymentPropertiesResolver.STATEFUL_SET_IMAGE_NAME);
+		assertThat(statefulSetInitContainer.getSecurityContext()).isNull();
 
         Assertions.assertThat(statefulSetSpec.getPodManagementPolicy()).isEqualTo("Parallel");
         Assertions.assertThat(statefulSetSpec.getReplicas()).isEqualTo(3);
@@ -772,8 +781,8 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
     @Test
     public void testCreateStatefulSetInitContainerImageNamePropOverride() throws Exception {
         Map<String, String> props = new HashMap<>();
-        props.put(KubernetesAppDeployer.COUNT_PROPERTY_KEY, "3");
-        props.put(KubernetesAppDeployer.INDEXED_PROPERTY_KEY, "true");
+        props.put(AppDeployer.COUNT_PROPERTY_KEY, "3");
+        props.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
 
         String imageName = testApplication().getURI().getSchemeSpecificPart();
 
@@ -822,8 +831,8 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
     @Test
     public void createStatefulSetInitContainerImageNameGlobalOverride() throws Exception {
         Map<String, String> props = new HashMap<>();
-        props.put(KubernetesAppDeployer.COUNT_PROPERTY_KEY, "3");
-        props.put(KubernetesAppDeployer.INDEXED_PROPERTY_KEY, "true");
+        props.put(AppDeployer.COUNT_PROPERTY_KEY, "3");
+        props.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
 
         AppDefinition definition = new AppDefinition(randomName(), null);
         AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, testApplication(), props);
@@ -873,8 +882,8 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
     @Test
     public void createStatefulSetWithOverridingRequest() throws Exception {
         Map<String, String> props = new HashMap<>();
-        props.put(KubernetesAppDeployer.COUNT_PROPERTY_KEY, "3");
-        props.put(KubernetesAppDeployer.INDEXED_PROPERTY_KEY, "true");
+        props.put(AppDeployer.COUNT_PROPERTY_KEY, "3");
+        props.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
         props.put("spring.cloud.deployer.kubernetes.statefulSet.volumeClaimTemplate.name", "mystorage");
         props.put("spring.cloud.deployer.kubernetes.statefulSet.volumeClaimTemplate.storage", "1g");
 
@@ -944,8 +953,8 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
     @Test
     public void createStatefulSetWithPVCDefaultName() throws Exception {
         Map<String, String> props = new HashMap<>();
-        props.put(KubernetesAppDeployer.COUNT_PROPERTY_KEY, "3");
-        props.put(KubernetesAppDeployer.INDEXED_PROPERTY_KEY, "true");
+        props.put(AppDeployer.COUNT_PROPERTY_KEY, "3");
+        props.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
         AppDefinition definition = new AppDefinition(randomName(), null);
         AppDeploymentRequest appDeploymentRequest = new AppDeploymentRequest(definition, testApplication(), props);
 
@@ -991,8 +1000,8 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
         Resource resource = testApplication();
 
         Map<String, String> props = new HashMap<>();
-        props.put(KubernetesAppDeployer.COUNT_PROPERTY_KEY, "3");
-        props.put(KubernetesAppDeployer.INDEXED_PROPERTY_KEY, "true");
+        props.put(AppDeployer.COUNT_PROPERTY_KEY, "3");
+        props.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
         props.put("spring.cloud.deployer.kubernetes.podAnnotations",
                 "iam.amazonaws.com/role:role-arn,foo:bar");
         AppDeploymentRequest request = new AppDeploymentRequest(definition, resource, props);
@@ -1072,8 +1081,8 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
     public void testDeploymentLabelsStatefulSet() {
         log.info("Testing {}...", "DeploymentLabelsForStatefulSet");
         Map<String, String> props = new HashMap<>();
-        props.put(KubernetesAppDeployer.COUNT_PROPERTY_KEY, "2");
-        props.put(KubernetesAppDeployer.INDEXED_PROPERTY_KEY, "true");
+        props.put(AppDeployer.COUNT_PROPERTY_KEY, "2");
+        props.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
         props.put("spring.cloud.deployer.kubernetes.deploymentLabels",
                 "stateful-label1:stateful-value1,stateful-label2:stateful-value2");
         AppDefinition definition = new AppDefinition(randomName(), null);
@@ -1186,8 +1195,7 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
         log.info("Testing {}...", "MultipleContainersInPod");
 
         KubernetesAppDeployer kubernetesAppDeployer = Mockito.spy(kubernetesAppDeployer());
-
-        AppDefinition definition = new AppDefinition(randomName(), Collections.singletonMap("server.port", "9090"));
+		AppDefinition definition = new AppDefinition(randomName(), Collections.singletonMap("server.port", "9090"));
         Resource resource = testApplication();
 
         AppDeploymentRequest request = new AppDeploymentRequest(definition, resource);
@@ -1669,6 +1677,167 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
                     assertThat(appDeployer().status(deploymentId).getState()).isEqualTo(DeploymentState.unknown);
                 });
     }
+
+	@Nested
+	class SecurityContextTests {
+
+		@Test
+		void podWithInitContainerAndAdditionalContainers() {
+
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put("spring.cloud.deployer.kubernetes.initContainer",
+					"{ containerName: 'init-container-5150', imageName: 'busybox:latest', commands: ['sh', '-c', 'echo hello']}");
+			deploymentProps.put("spring.cloud.deployer.kubernetes.additional-containers",
+					"[" +
+						"{ name: 'extra-container-5150', image: 'busybox:latest', command: ['sh', '-c'], args: [\"while true; do echo ‘hello 5150’ & sleep 2; done\"]}," +
+						"{ name: 'extra-container-6160', image: 'busybox:latest', command: ['sh', '-c'], args: [\"while true; do echo ‘hello 5150’ & sleep 2; done\"]}" +
+					"]");
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext",
+					"{ fsGroup: 65534" +
+						", fsGroupChangePolicy: Always" +
+						", runAsUser: 65534" +
+						", runAsGroup: 65534" +
+						", seLinuxOptions: { level: \"s0:c123,c456\" }" +
+					"}");
+			deploymentProps.put("spring.cloud.deployer.kubernetes.containerSecurityContext",
+					"{ allowPrivilegeEscalation: true" +
+						", runAsUser: 65534" +
+						", runAsGroup: 65534" +
+						", seLinuxOptions: { level: \"s0:c123,c777\" }" +
+					"}");
+
+			AppDefinition definition = new AppDefinition(randomName(), null);
+			AppDeploymentRequest request = new AppDeploymentRequest(definition, testApplication(), deploymentProps);
+
+			KubernetesDeployerProperties deployProperties = new KubernetesDeployerProperties();
+			deployProperties.setCreateLoadBalancer(true);
+			deployProperties.setMinutesToWaitForLoadBalancer(1);
+			KubernetesAppDeployer kubernetesAppDeployer = kubernetesAppDeployer(deployProperties);
+
+			log.info("Deploying {}...", request.getDefinition().getName());
+			String deploymentId = kubernetesAppDeployer.deploy(request);
+
+			Timeout timeout = deploymentTimeout();
+			await().pollInterval(Duration.ofMillis(timeout.pause))
+					.atMost(Duration.ofMillis(timeout.maxAttempts * timeout.pause))
+					.untilAsserted(() -> assertThat(appDeployer().status(deploymentId).getState()).isEqualTo(DeploymentState.deployed));
+
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withFsGroup(65534L)
+					.withFsGroupChangePolicy("Always")
+					.withRunAsUser(65534L)
+					.withRunAsGroup(65534L)
+					.withSeLinuxOptions(new SELinuxOptions("s0:c123,c456", null, null, null))
+					.build();
+
+			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
+					.withAllowPrivilegeEscalation(true)
+					.withRunAsUser(65534L)
+					.withRunAsGroup(65534L)
+					.withSeLinuxOptions(new SELinuxOptions("s0:c123,c777", null, null, null))
+					.build();
+
+			Deployment deployment = kubernetesClient.apps().deployments().withName(request.getDefinition().getName()).get();
+
+			assertThat(deployment.getSpec().getTemplate().getSpec().getSecurityContext())
+					.isEqualTo(expectedPodSecurityContext);
+
+			assertThatContainerExistsWithSecurityContext(deployment.getSpec().getTemplate().getSpec().getInitContainers(),
+					"init-container-5150", expectedContainerSecurityContext);
+
+			assertThatContainerExistsWithSecurityContext(deployment.getSpec().getTemplate().getSpec().getContainers(),
+					"extra-container-5150", expectedContainerSecurityContext);
+
+			assertThatContainerExistsWithSecurityContext(deployment.getSpec().getTemplate().getSpec().getContainers(),
+					"extra-container-6160", expectedContainerSecurityContext);
+
+			log.info("Undeploying {}...", deploymentId);
+			timeout = undeploymentTimeout();
+			kubernetesAppDeployer.undeploy(deploymentId);
+			await().pollInterval(Duration.ofMillis(timeout.pause))
+					.atMost(Duration.ofMillis(timeout.maxAttempts * timeout.pause))
+					.untilAsserted(() -> assertThat(appDeployer().status(deploymentId).getState()).isEqualTo(DeploymentState.unknown));
+		}
+
+		@Test
+		void statefulSetWithInitContainerAndAdditionalContainers() throws IOException {
+
+			Map<String, String> deploymentProps = new HashMap<>();
+			deploymentProps.put(AppDeployer.COUNT_PROPERTY_KEY, "2");
+			deploymentProps.put(AppDeployer.INDEXED_PROPERTY_KEY, "true");
+			deploymentProps.put("spring.cloud.deployer.kubernetes.podSecurityContext",
+					"{ fsGroup: 65534" +
+							", fsGroupChangePolicy: Always" +
+							", runAsUser: 65534" +
+							", runAsGroup: 65534" +
+							", seLinuxOptions: { level: \"s0:c123,c456\" }" +
+							"}");
+			deploymentProps.put("spring.cloud.deployer.kubernetes.containerSecurityContext",
+					"{ allowPrivilegeEscalation: true" +
+							", runAsUser: 65534" +
+							", runAsGroup: 65534" +
+							", seLinuxOptions: { level: \"s0:c123,c777\" }" +
+							"}");
+
+			AppDefinition definition = new AppDefinition(randomName(), null);
+			AppDeploymentRequest request = new AppDeploymentRequest(definition, testApplication(), deploymentProps);
+
+			String imageName = testApplication().getURI().getSchemeSpecificPart();
+			KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+			kubernetesDeployerProperties.setStatefulSetInitContainerImageName(imageName);
+			KubernetesAppDeployer kubernetesAppDeployer = kubernetesAppDeployer(kubernetesDeployerProperties);
+
+			log.info("Deploying {}...", request.getDefinition().getName());
+			String deploymentId = kubernetesAppDeployer.deploy(request);
+
+			Timeout timeout = deploymentTimeout();
+			await().pollInterval(Duration.ofMillis(timeout.pause))
+					.atMost(Duration.ofMillis(timeout.maxAttempts * timeout.pause))
+					.untilAsserted(() -> assertThat(appDeployer().status(deploymentId).getState()).isEqualTo(DeploymentState.deployed));
+
+			PodSecurityContext expectedPodSecurityContext = new PodSecurityContextBuilder()
+					.withFsGroup(65534L)
+					.withFsGroupChangePolicy("Always")
+					.withRunAsUser(65534L)
+					.withRunAsGroup(65534L)
+					.withSeLinuxOptions(new SELinuxOptions("s0:c123,c456", null, null, null))
+					.build();
+
+			SecurityContext expectedContainerSecurityContext = new SecurityContextBuilder()
+					.withAllowPrivilegeEscalation(true)
+					.withRunAsUser(65534L)
+					.withRunAsGroup(65534L)
+					.withSeLinuxOptions(new SELinuxOptions("s0:c123,c777", null, null, null))
+					.build();
+
+			Map<String, String> selector = Collections.singletonMap(AbstractKubernetesDeployer.SPRING_APP_KEY, deploymentId);
+			List<StatefulSet> statefulSets = kubernetesClient.apps().statefulSets().withLabels(selector).list().getItems();
+			assertThat(statefulSets).hasSize(1)
+					.element(0, InstanceOfAssertFactories.type(StatefulSet.class))
+					.extracting("spec.template.spec", InstanceOfAssertFactories.type(PodSpec.class))
+					.satisfies((podSpec) -> {
+						assertThat(podSpec.getSecurityContext()).isEqualTo(expectedPodSecurityContext);
+						assertThat(podSpec.getInitContainers())
+								.hasSize(1)
+								.element(0, InstanceOfAssertFactories.type(Container.class))
+								.extracting(Container::getSecurityContext).isEqualTo(expectedContainerSecurityContext);
+					});
+
+			log.info("Undeploying {}...", deploymentId);
+			timeout = undeploymentTimeout();
+			kubernetesAppDeployer.undeploy(deploymentId);
+			await().pollInterval(Duration.ofMillis(timeout.pause))
+					.atMost(Duration.ofMillis(timeout.maxAttempts * timeout.pause))
+					.untilAsserted(() -> assertThat(appDeployer().status(deploymentId).getState()).isEqualTo(DeploymentState.unknown));
+		}
+
+	}
+
+	private void assertThatContainerExistsWithSecurityContext(List<Container> containers, String expectedName, SecurityContext expectedSecurityContext) {
+		assertThat(containers
+				.stream().filter(c -> c.getName().equals(expectedName)).findFirst())
+				.hasValueSatisfying((initContainer) -> assertThat(initContainer.getSecurityContext()).isEqualTo(expectedSecurityContext));
+	}
 
     @Test
     public void testUnknownStatusOnPendingResources() throws InterruptedException {
@@ -2335,7 +2504,7 @@ public class KubernetesAppDeployerIntegrationIT extends AbstractAppDeployerInteg
 
     @Override
     protected String randomName() {
-        // Kubernetest service names must start with a letter and can only be 24 characters long
+        // Kubernetes service names must start with a letter and can only be 24 characters long
         return "app-" + UUID.randomUUID().toString().substring(0, 18);
     }
 

--- a/src/test/resources/dataflow-server-containerSecurityContext.yml
+++ b/src/test/resources/dataflow-server-containerSecurityContext.yml
@@ -1,4 +1,25 @@
 # spring.cloud.deployer.kubernetes.containerSecurityContext:
 containerSecurityContext:
   allowPrivilegeEscalation: true
-  readOnlyRootFilesystem: false
+  capabilities:
+    add:
+      - "a"
+      - "b"
+    drop:
+      - "c"
+  privileged: true
+  procMount: DefaultProcMount
+  readOnlyRootFilesystem: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  runAsNonRoot: true
+  seLinuxOptions:
+    level: "s0:c123,c456"
+  seccompProfile:
+    type: Localhost
+    localhostProfile: my-profiles/profile-allow.json
+  windowsOptions:
+    gmsaCredentialSpec: specA
+    gmsaCredentialSpecName: specA-name
+    hostProcess: true
+    runAsUserName: userA

--- a/src/test/resources/dataflow-server-podsecuritycontext.yml
+++ b/src/test/resources/dataflow-server-podsecuritycontext.yml
@@ -1,8 +1,25 @@
 # spring.cloud.deployer.kubernetes.podSecurityContext:
 podSecurityContext:
-  runAsUser: 65534
   fsGroup: 65534
-  supplementalGroups: [65534,65535]
+  fsGroupChangePolicy: Always
+  runAsUser: 65534
+  runAsGroup: 65534
+  runAsNonRoot: true
+  seLinuxOptions:
+    level: "s0:c123,c456"
   seccompProfile:
     type: Localhost
     localhostProfile: my-profiles/profile-allow.json
+  supplementalGroups:
+    - 65534
+    - 65535
+  sysctls:
+    - name: "kernel.shm_rmid_forced"
+      value: 0
+    - name: "net.core.somaxconn"
+      value: 1024
+  windowsOptions:
+    gmsaCredentialSpec: specA
+    gmsaCredentialSpecName: specA-name
+    hostProcess: true
+    runAsUserName: userA


### PR DESCRIPTION
* Add context to additional containers
* Add all available config props on security contexts

Co-authored-by: asinrus <arkadii_osheev@mail.ru>

See https://github.com/spring-cloud/spring-cloud-dataflow/issues/5184 See https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/issues/512