### PR TITLE
Add ttlSecondsAfterFinished cronjob spec to KubernetesScheduler

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesDeployerProperties.java
@@ -1484,6 +1484,8 @@ public class KubernetesDeployerProperties {
 	public static class CronConfig {
 		private String concurrencyPolicy;
 
+        private Integer ttlSecondsAfterFinished;
+
 		public String getConcurrencyPolicy() {
 			return concurrencyPolicy;
 		}
@@ -1491,6 +1493,14 @@ public class KubernetesDeployerProperties {
 		public void setConcurrencyPolicy(String concurrencyPolicy) {
 			this.concurrencyPolicy = concurrencyPolicy;
 		}
+
+        public Integer getTtlSecondsAfterFinished() {
+            return ttlSecondsAfterFinished;
+        }
+
+        public void setTtlSecondsAfterFinished(Integer ttlSecondsAfterFinished) {
+            this.ttlSecondsAfterFinished = ttlSecondsAfterFinished;
+        }
 	}
 
     public Boolean getShareProcessNamespace() {

--- a/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesScheduler.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesScheduler.java
@@ -216,10 +216,12 @@ public class KubernetesScheduler extends AbstractKubernetesDeployer implements S
 			concurrencyPolicy = "Allow";
 		}
 
-		Integer ttlSecondsAfterFinished = null;
+		final Integer ttlSecondsAfterFinished;
 		String ttlSecondsAfterFinishedString = schedulerProperties.get(KUBERNETES_DEPLOYER_CRON_TTL_SECONDS_AFTER_FINISHED);
-		if (StringUtils.hasText(ttlSecondsAfterFinishedString) && Pattern.matches("^[0-9]+$", ttlSecondsAfterFinishedString)) {
+		if (StringUtils.hasText(ttlSecondsAfterFinishedString)) {
 			ttlSecondsAfterFinished = Integer.parseInt(ttlSecondsAfterFinishedString);
+		} else {
+			ttlSecondsAfterFinished = this.properties.getCron().getTtlSecondsAfterFinished();
 		}
 
 		PodSpec podSpec = createPodSpec(new ScheduleRequest(scheduleRequest.getDefinition(),schedulerProperties, scheduleRequest.getCommandlineArguments(), scheduleRequest.getScheduleName(),scheduleRequest.getResource()));

--- a/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesSchedulerIT.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/kubernetes/KubernetesSchedulerIT.java
@@ -107,12 +107,12 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	protected Map<String, String> getSchedulerProperties() {
 		return Collections.singletonMap(SchedulerPropertyKeys.CRON_EXPRESSION, "57 13 ? * *");
 	}
-	
-	
+
+
 	private Map<String, String> getSchedulerProperties(String concurrencyPolicy) {
 		Map<String, String> schedulerProperties = new HashMap<>(getSchedulerProperties());
 		schedulerProperties.put(KubernetesScheduler.KUBERNETES_DEPLOYER_CRON_CONCURRENCY_POLICY, concurrencyPolicy);
-		return schedulerProperties;		
+		return schedulerProperties;
 	}
 
 	@Override
@@ -195,12 +195,12 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 
 		assertThat(mergedProperties
 				.get(KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX + ".imagePullPolicy"))
-						.as("Expected value from Scheduler properties, but found in Deployer properties")
-						.isEqualTo("Never");
+				.as("Expected value from Scheduler properties, but found in Deployer properties")
+				.isEqualTo("Never");
 		assertThat(mergedProperties
 				.get(KubernetesDeployerProperties.KUBERNETES_DEPLOYER_PROPERTIES_PREFIX + ".environmentVariables"))
-						.as("Deployer property is expected to be merged as scheduler property")
-						.isEqualTo("MYVAR1=MYVAL1,MYVAR2=MYVAL2");
+				.as("Deployer property is expected to be merged as scheduler property")
+				.isEqualTo("MYVAR1=MYVAL1,MYVAR2=MYVAL2");
 	}
 
 	@Test
@@ -282,7 +282,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		assertThatThrownBy(() -> {
 			scheduler.schedule(scheduleRequest2);
 		}).isInstanceOf(CreateScheduleException.class)
-			.hasMessage(String.format("Failed to create schedule because Schedule Name: '%s' has too many characters.  Schedule name length must be 52 characters or less", baseScheduleName + "1"));
+				.hasMessage(String.format("Failed to create schedule because Schedule Name: '%s' has too many characters.  Schedule name length must be 52 characters or less", baseScheduleName + "1"));
 	}
 
 	@ParameterizedTest
@@ -321,7 +321,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testWithShellEntryPoint(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -354,7 +354,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testWithBootEntryPoint(boolean isDeprecated) throws IOException {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		kubernetesDeployerProperties.setEntryPointStyle(EntryPointStyle.boot);
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
@@ -432,7 +432,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testEntryPointStyleOverride(boolean isDeprecated) throws Exception {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -474,7 +474,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testEntryPointStyleDefault(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -503,7 +503,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testImagePullPolicyOverride(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -536,7 +536,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testJobAnnotationsAndLabelsFromSchedulerProperties(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		kubernetesDeployerProperties.setJobAnnotations("test1:value1");
 		kubernetesDeployerProperties.setPodAnnotations("podtest1:podvalue1");
 		kubernetesDeployerProperties.setDeploymentLabels("label1:value1,label2:value2");
@@ -592,7 +592,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testJobAnnotationsAndLabelsFromSchedulerRequest(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		kubernetesDeployerProperties.setJobAnnotations("test1:value1");
 		kubernetesDeployerProperties.setPodAnnotations("podtest1:podvalue1");
 		kubernetesDeployerProperties.setDeploymentLabels("label1:value1,label2:value2");
@@ -636,7 +636,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testJobAnnotationsOverride(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		kubernetesDeployerProperties.setJobAnnotations("test1:value1");
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
@@ -666,7 +666,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testImagePullPolicyDefault(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -678,7 +678,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
 		ScheduleRequest scheduleRequest = (isDeprecated) ? new ScheduleRequest(appDefinition, getSchedulerProperties(), Collections.emptyMap(), getCommandLineArgs(), randomName(), testApplication()) :
-			new ScheduleRequest(appDefinition, getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
+				new ScheduleRequest(appDefinition, getDeploymentProperties(), getCommandLineArgs(), randomName(), testApplication());
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 		CronJobSpec cronJobSpec = cronJob.getSpec();
 
@@ -693,7 +693,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testImagePullSecret(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -726,7 +726,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testImagePullSecretDefault(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -754,7 +754,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testImagePullSecretFromSchedulerProperties(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -800,7 +800,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testGlobalEnvironmentVariables(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -831,7 +831,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testGlobalAndCustomEnvironmentVariables(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
@@ -855,7 +855,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testCustomEnvironmentVariablesOverrideGlobal(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -903,7 +903,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testTaskServiceAccountNameOverride(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -937,7 +937,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 	@ValueSource(booleans = {true, false})
 	public void testTaskServiceAccountNameDefault(boolean isDeprecated) {
 		KubernetesDeployerProperties kubernetesDeployerProperties =
-						new KubernetesDeployerProperties();
+				new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
@@ -962,7 +962,7 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
-	
+
 	@ParameterizedTest
 	@ValueSource(strings = {"Forbid","Allow","Replace"})
 	public void testConcurrencyPolicy(String concurrencyPolicy) {
@@ -978,13 +978,62 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
 		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(concurrencyPolicy),
-				 getCommandLineArgs(), randomName(), testApplication());
+				getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 
 		assertThat(cronJob.getSpec().getConcurrencyPolicy()).isEqualTo(concurrencyPolicy);
-		
-		
+
+
+		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
+	}
+
+	@Test
+	public void testConcurrencyPolicyDefault() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
+		}
+		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
+
+		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
+				kubernetesDeployerProperties);
+
+		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
+		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
+				getCommandLineArgs(), randomName(), testApplication());
+
+		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
+
+		assertThat(cronJob.getSpec().getConcurrencyPolicy()).isEqualTo("Allow");
+
+
+		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
+	}
+
+	@Test
+	public void testConcurrencyPolicyFromServerProperties() {
+		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
+		if (kubernetesDeployerProperties.getNamespace() == null) {
+			kubernetesDeployerProperties.setNamespace("default");
+		}
+		kubernetesDeployerProperties.getCron().setConcurrencyPolicy("Forbid");
+		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
+				.inNamespace(kubernetesDeployerProperties.getNamespace());
+
+		KubernetesScheduler kubernetesScheduler = new KubernetesScheduler(kubernetesClient,
+				kubernetesDeployerProperties);
+
+		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
+		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
+				getCommandLineArgs(), randomName(), testApplication());
+
+		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
+
+		assertThat(cronJob.getSpec().getConcurrencyPolicy()).isEqualTo("Forbid");
+
+
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
@@ -1013,12 +1062,26 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 		assertThat(cronJob.getSpec().getJobTemplate().getSpec().getTtlSecondsAfterFinished())
 				.isEqualTo(Integer.parseInt(ttlSecondsAfterFinished));
 
-
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
 
+	@ParameterizedTest
+	@ValueSource(strings = {"100 2", "one", "10'"})
+	public void testInvalidTtlSecondsAfterFinished(String ttlSecondsAfterFinished) {
+		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
+		Map<String, String> schedulerProperties = new HashMap<>(getSchedulerProperties());
+		schedulerProperties.put(KubernetesScheduler.KUBERNETES_DEPLOYER_CRON_TTL_SECONDS_AFTER_FINISHED, ttlSecondsAfterFinished);
+
+		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, schedulerProperties,
+				getCommandLineArgs(), randomName(), testApplication());
+
+		assertThatThrownBy(() -> {
+			scheduler.schedule(scheduleRequest);
+		}).isInstanceOf(NumberFormatException.class);
+	}
+
 	@Test
-	public void testConcurencyPolicyDefault() {
+	public void testTtlSecondsAfterFinishedDefault() {
 		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
@@ -1030,24 +1093,25 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 				kubernetesDeployerProperties);
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
+
 		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
-				 getCommandLineArgs(), randomName(), testApplication());
+				getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 
-		assertThat(cronJob.getSpec().getConcurrencyPolicy()).isEqualTo("Allow");
-		
-		
+		assertThat(cronJob.getSpec().getJobTemplate().getSpec().getTtlSecondsAfterFinished())
+				.isNull();
+
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
-	
+
 	@Test
-	public void testConcurencyPolicyFromServerProperties() {
+	public void testTtlSecondsAfterFinishedFromServerProperties() {
 		KubernetesDeployerProperties kubernetesDeployerProperties = new KubernetesDeployerProperties();
 		if (kubernetesDeployerProperties.getNamespace() == null) {
 			kubernetesDeployerProperties.setNamespace("default");
 		}
-		kubernetesDeployerProperties.getCron().setConcurrencyPolicy("Forbid");
+		kubernetesDeployerProperties.getCron().setTtlSecondsAfterFinished(86400);
 		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
 				.inNamespace(kubernetesDeployerProperties.getNamespace());
 
@@ -1056,16 +1120,15 @@ public class KubernetesSchedulerIT extends AbstractSchedulerIntegrationJUnit5Tes
 
 		AppDefinition appDefinition = new AppDefinition(randomName(), getAppProperties());
 		ScheduleRequest scheduleRequest = new ScheduleRequest(appDefinition, getSchedulerProperties(),
-				 getCommandLineArgs(), randomName(), testApplication());
+				getCommandLineArgs(), randomName(), testApplication());
 
 		CronJob cronJob = kubernetesScheduler.createCronJob(scheduleRequest);
 
-		assertThat(cronJob.getSpec().getConcurrencyPolicy()).isEqualTo("Forbid");
-		
-		
+		assertThat(cronJob.getSpec().getJobTemplate().getSpec().getTtlSecondsAfterFinished()).isEqualTo(86400);
+
+
 		kubernetesScheduler.unschedule(cronJob.getMetadata().getName());
 	}
-	
 
 	@AfterAll
 	public static void cleanup() {


### PR DESCRIPTION
Added ttlSecondsAfterFinished setting to automatically delete jobs 
when creating cronjob in spring-cloud-dataflow.